### PR TITLE
Generate Readme from code

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ get a component's name from the reference
 
 ### compare ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.test.js) )
 
-compare two values, with an operator.<br />note: if you don't pass an operator, it assumes  `===`
+compare two values, with an operator.<br />note: if you don't pass an operator, it assumes  `===` <br />note: this can be used as a block  _or_  inline helper
 
 #### Params
 * `left` _(*)_ left value
@@ -161,6 +161,13 @@ compare two values, with an operator.<br />note: if you don't pass an operator, 
 * `[options]` _(object)_ 
 
 **Returns** _(string)_ if inline, otherwise calls block functions
+
+#### Example
+
+```hbs
+{{ compare 10 ">" 5 }}
+//=> &quot;true&quot;
+```
 
 ### if ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.test.js) )
 
@@ -245,11 +252,7 @@ set data into current context
 
 ### addCommas ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.test.js) )
 
-add commas to numbers.<br />note: this overrides handlebars-helpers' addCommas helper
-because we want to preserve zeroes in decimals (for money)
-e.g. 1234.50 → 1,234.50 instead of 1,234.5
-note: decimals are only preserved if passed in as a string
-(they don't exist in js numbers)
+add commas to numbers.<br />note: this overrides handlebars-helpers' addCommas helper<br />because we want to preserve zeroes in decimals (for money)<br />e.g. 1234.50 → 1,234.50 instead of 1,234.5<br />note: decimals are only preserved if passed in as a string<br />(they don't exist in js numbers)
 
 #### Params
 * `num` _(number|string)_ 
@@ -270,8 +273,7 @@ convert number to shorthand<br />e.g. 1000 → 1k
 
 ### commaSeparated ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/objects/commaSeparated.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/objects/commaSeparated.test.js) )
 
-Turn an object into a comma-delineated list of key names,<br />based on if their values are true/false
-e.g. { a: true, b: false, c: true } → a, b, c
+Turn an object into a comma-delineated list of key names,<br />based on if their values are true/false<br />e.g. { a: true, b: false, c: true } → a, b, c
 
 #### Params
 * `obj` _(object)_ 
@@ -299,8 +301,7 @@ returns the number of characters in the longest word of<br />a string. Punctuati
 
 ### randomString ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.test.js) )
 
-generatea random string<br />e.g.  `greatest-hit-`  →  `greatest-hit-noctz56h` 
-note: allows passing length=x to generate strings of different lengths
+generatea random string<br />e.g.  `greatest-hit-`  →  `greatest-hit-noctz56h` <br />note: allows passing length=x to generate strings of different lengths
 
 #### Params
 * `[prefix]` _(string)_ 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ By default, `nymag-handlebars` will export a function that returns a new handleb
 
 ```js
 var hbs = require('nymag-handlebars')(),
-  template = hbs.compile('<h1>Hello {{ place }}!</h1>'),
+  template = hbs.compile('&lt;h1&gt;Hello {{ place }}!&lt;/h1&gt;'),
   result = template({ place: 'World' });
 
-// result: <h1>Hello World!</h1>
+// result: &lt;h1&gt;Hello World!&lt;/h1&gt;
 ```
 
 ## Passing env in
@@ -37,3 +37,191 @@ var Handlebars = require('express-handlebars'),
 app.engine('handlebars', hbs.engine);
 app.set('view engine', 'handlebars');
 ```
+
+---
+
+# Helpers
+
+Currently **21 helpers** in **9 categories**:
+
+### components
+
+* [displaySelf](https://github.com/nymag/nymag-handlebars#displaySelf)
+* [displaySelfAll](https://github.com/nymag/nymag-handlebars#displaySelfAll)
+* [getComponentName](https://github.com/nymag/nymag-handlebars#getComponentName)
+### conditionals
+
+* [compare](https://github.com/nymag/nymag-handlebars#compare)
+* [if](https://github.com/nymag/nymag-handlebars#if)
+* [ifAll](https://github.com/nymag/nymag-handlebars#ifAll)
+* [ifAny](https://github.com/nymag/nymag-handlebars#ifAny)
+* [ifNone](https://github.com/nymag/nymag-handlebars#ifNone)
+* [modulo](https://github.com/nymag/nymag-handlebars#modulo)
+### html
+
+* [striptags](https://github.com/nymag/nymag-handlebars#striptags)
+* [wordCount](https://github.com/nymag/nymag-handlebars#wordCount)
+### misc
+
+* [indexOf](https://github.com/nymag/nymag-handlebars#indexOf)
+* [set](https://github.com/nymag/nymag-handlebars#set)
+### numbers
+
+* [addCommas](https://github.com/nymag/nymag-handlebars#addCommas)
+* [toK](https://github.com/nymag/nymag-handlebars#toK)
+### objects
+
+* [commaSeparated](https://github.com/nymag/nymag-handlebars#commaSeparated)
+### strings
+
+* [kebabCase](https://github.com/nymag/nymag-handlebars#kebabCase)
+* [longestWord](https://github.com/nymag/nymag-handlebars#longestWord)
+* [randomString](https://github.com/nymag/nymag-handlebars#randomString)
+### time
+
+* [articleDate](https://github.com/nymag/nymag-handlebars#articleDate)
+### urls
+
+* [urlencode](https://github.com/nymag/nymag-handlebars#urlencode)
+
+---
+
+## components
+
+**displaySelf** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelf.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelf.test.js) )
+
+_No description_
+
+
+**displaySelfAll** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelfAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelfAll.test.js) )
+
+_No description_
+
+
+**getComponentName** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/getComponentName.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/getComponentName.test.js) )
+
+_No description_
+
+
+## conditionals
+
+**compare** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.test.js) )
+
+_No description_
+
+
+**if** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.test.js) )
+
+_No description_
+
+
+**ifAll** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAll.test.js) )
+
+_No description_
+
+
+**ifAny** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAny.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAny.test.js) )
+
+_No description_
+
+
+**ifNone** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifNone.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifNone.test.js) )
+
+_No description_
+
+
+**modulo** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/modulo.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/modulo.test.js) )
+
+_No description_
+
+
+## html
+
+**striptags** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/striptags.js) | no tests )
+
+_No description_
+
+
+**wordCount** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/wordCount.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/wordCount.test.js) )
+
+_No description_
+
+
+## misc
+
+**indexOf** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/indexOf.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/indexOf.test.js) )
+
+_No description_
+
+
+**set** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.test.js) )
+
+_No description_
+
+
+## numbers
+
+**addCommas** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.test.js) )
+
+_No description_
+
+
+**toK** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.test.js) )
+
+_No description_
+
+
+## objects
+
+**commaSeparated** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/objects/commaSeparated.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/objects/commaSeparated.test.js) )
+
+_No description_
+
+
+## strings
+
+**kebabCase** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/kebabCase.js) | no tests )
+
+_No description_
+
+
+**longestWord** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.test.js) )
+
+_No description_
+
+
+**randomString** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.test.js) )
+
+_No description_
+
+
+## time
+
+**articleDate** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/articleDate.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/articleDate.test.js) )
+
+_No description_
+
+
+## urls
+
+**urlencode** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/urls/urlencode.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/urls/urlencode.test.js) )
+
+_No description_
+
+
+
+---
+
+# Partials
+
+Currently **1 partial**:
+
+* **component-list** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/partials/component-list.hbs) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/partials/component-list.test.js) )
+
+---
+
+# Contributing
+
+Pull requests and stars are always welcome. For bugs and feature requests, [please create an issue](https://github.com/nymag/nymag-handlebars/issues/new).
+
+This project is released under the [MIT license](https://github.com/nymag/nymag-handlebars/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -152,24 +152,24 @@ get a component's name from the reference
 
 ### compare ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.test.js) )
 
-compare two values, with an operator.<br />note: if you don't pass an operator, it assumes '==='
+compare two values, with an operator.<br />note: if you don't pass an operator, it assumes  `===`
 
 #### Params
-* `left` left value
-* `operator` _(string)_ 
-* `right` right value
-* `options` 
+* `left` _(*)_ left value
+* `operator` _(string)_ to compare with
+* `right` _(*)_ right value
+* `[options]` _(object)_ 
 
-**Returns** _(string)_ 
+**Returns** _(string)_ if inline, otherwise calls block functions
 
 ### if ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.test.js) )
 
 if
 
 #### Params
-* `conditional` to check for truthiness
-* `value` to print if conditional is truthy
-* `options` 
+* `conditional` _(*)_ to check for truthiness
+* `value` _(*)_ to print if conditional is truthy
+* `[options]` _(object)_ 
 
 **Returns** _(string)_ 
 
@@ -217,7 +217,7 @@ _No description_
 counts the words in a string of text or html
 
 #### Params
-* `html` 
+* `[html]` _(string)_ 
 
 **Returns** _(string)_ 
 
@@ -236,7 +236,7 @@ set data into current context
 
 #### Params
 * `key` _(string)_ _.set() key/path
-* `val` 
+* `val` _(*)_ 
 
 **Returns** _(string)_ doesn't actually print anything
 
@@ -252,7 +252,7 @@ note: decimals are only preserved if passed in as a string
 (they don't exist in js numbers)
 
 #### Params
-* `num` 
+* `num` _(number|string)_ 
 
 **Returns** _(string)_ 
 
@@ -261,7 +261,7 @@ note: decimals are only preserved if passed in as a string
 convert number to shorthand<br />e.g. 1000 → 1k
 
 #### Params
-* `x` 
+* `x` _(number|string)_ 
 
 **Returns** _(string)_ 
 
@@ -303,8 +303,8 @@ generatea random string<br />e.g.  `greatest-hit-`  →  `greatest-hit-noctz56h`
 note: allows passing length=x to generate strings of different lengths
 
 #### Params
-* `prefix` 
-* `options` 
+* `[prefix]` _(string)_ 
+* `[options]` _(object)_ 
 
 **Returns** _(string)_ 
 

--- a/README.md
+++ b/README.md
@@ -44,167 +44,253 @@ app.set('view engine', 'handlebars');
 
 Currently **21 helpers** in **9 categories**:
 
+
 ### components
 
-* [displaySelf](https://github.com/nymag/nymag-handlebars#displaySelf)
-* [displaySelfAll](https://github.com/nymag/nymag-handlebars#displaySelfAll)
-* [getComponentName](https://github.com/nymag/nymag-handlebars#getComponentName)
+* [**displaySelf**](https://github.com/nymag/nymag-handlebars#displaySelf) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelf.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelf.test.js) )
+* [**displaySelfAll**](https://github.com/nymag/nymag-handlebars#displaySelfAll) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelfAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelfAll.test.js) )
+* [**getComponentName**](https://github.com/nymag/nymag-handlebars#getComponentName) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/getComponentName.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/getComponentName.test.js) )
+
 ### conditionals
 
-* [compare](https://github.com/nymag/nymag-handlebars#compare)
-* [if](https://github.com/nymag/nymag-handlebars#if)
-* [ifAll](https://github.com/nymag/nymag-handlebars#ifAll)
-* [ifAny](https://github.com/nymag/nymag-handlebars#ifAny)
-* [ifNone](https://github.com/nymag/nymag-handlebars#ifNone)
-* [modulo](https://github.com/nymag/nymag-handlebars#modulo)
+* [**compare**](https://github.com/nymag/nymag-handlebars#compare) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.test.js) )
+* [**if**](https://github.com/nymag/nymag-handlebars#if) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.test.js) )
+* [**ifAll**](https://github.com/nymag/nymag-handlebars#ifAll) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAll.test.js) )
+* [**ifAny**](https://github.com/nymag/nymag-handlebars#ifAny) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAny.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAny.test.js) )
+* [**ifNone**](https://github.com/nymag/nymag-handlebars#ifNone) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifNone.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifNone.test.js) )
+* [**modulo**](https://github.com/nymag/nymag-handlebars#modulo) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/modulo.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/modulo.test.js) )
+
 ### html
 
-* [striptags](https://github.com/nymag/nymag-handlebars#striptags)
-* [wordCount](https://github.com/nymag/nymag-handlebars#wordCount)
+* [**striptags**](https://github.com/nymag/nymag-handlebars#striptags) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/striptags.js) | no tests )
+* [**wordCount**](https://github.com/nymag/nymag-handlebars#wordCount) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/wordCount.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/wordCount.test.js) )
+
 ### misc
 
-* [indexOf](https://github.com/nymag/nymag-handlebars#indexOf)
-* [set](https://github.com/nymag/nymag-handlebars#set)
+* [**indexOf**](https://github.com/nymag/nymag-handlebars#indexOf) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/indexOf.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/indexOf.test.js) )
+* [**set**](https://github.com/nymag/nymag-handlebars#set) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.test.js) )
+
 ### numbers
 
-* [addCommas](https://github.com/nymag/nymag-handlebars#addCommas)
-* [toK](https://github.com/nymag/nymag-handlebars#toK)
+* [**addCommas**](https://github.com/nymag/nymag-handlebars#addCommas) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.test.js) )
+* [**toK**](https://github.com/nymag/nymag-handlebars#toK) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.test.js) )
+
 ### objects
 
-* [commaSeparated](https://github.com/nymag/nymag-handlebars#commaSeparated)
+* [**commaSeparated**](https://github.com/nymag/nymag-handlebars#commaSeparated) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/objects/commaSeparated.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/objects/commaSeparated.test.js) )
+
 ### strings
 
-* [kebabCase](https://github.com/nymag/nymag-handlebars#kebabCase)
-* [longestWord](https://github.com/nymag/nymag-handlebars#longestWord)
-* [randomString](https://github.com/nymag/nymag-handlebars#randomString)
+* [**kebabCase**](https://github.com/nymag/nymag-handlebars#kebabCase) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/kebabCase.js) | no tests )
+* [**longestWord**](https://github.com/nymag/nymag-handlebars#longestWord) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.test.js) )
+* [**randomString**](https://github.com/nymag/nymag-handlebars#randomString) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.test.js) )
+
 ### time
 
-* [articleDate](https://github.com/nymag/nymag-handlebars#articleDate)
+* [**articleDate**](https://github.com/nymag/nymag-handlebars#articleDate) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/articleDate.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/articleDate.test.js) )
+
 ### urls
 
-* [urlencode](https://github.com/nymag/nymag-handlebars#urlencode)
+* [**urlencode**](https://github.com/nymag/nymag-handlebars#urlencode) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/urls/urlencode.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/urls/urlencode.test.js) )
 
 ---
 
+
 ## components
 
-**displaySelf** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelf.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelf.test.js) )
+
+### displaySelf ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelf.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelf.test.js) )
+
+Return the first component (from a list of components) with a truthy displaySelf property. Used by Spaces.
+
+#### Params
+* `components` _(array)_ with displaySelf properties
+
+#### Returns
+first component with displaySelf: true
+
+#### Example
+
+```hbs
+{{> component-list (displaySelf content) }}
+
+```
+
+### displaySelfAll ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelfAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelfAll.test.js) )
 
 _No description_
 
 
-**displaySelfAll** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelfAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelfAll.test.js) )
 
-_No description_
+### getComponentName ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/getComponentName.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/getComponentName.test.js) )
 
+get a component&#x27;s name from the reference
 
-**getComponentName** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/getComponentName.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/getComponentName.test.js) )
-
-_No description_
-
+#### Params
+* `ref` _(string)_ 
 
 ## conditionals
 
-**compare** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.test.js) )
+
+### compare ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.test.js) )
+
+compare two values, with an operator
+note: if you don&#x27;t pass an operator, it assumes &#x27;&#x3D;&#x3D;&#x3D;&#x27;
+
+#### Params
+* `left` left value
+* `operator` _(string)_ 
+* `right` right value
+* `options` 
+
+### if ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.test.js) )
+
+if
+
+#### Params
+* `conditional` to check for truthiness
+* `value` to print if conditional is truthy
+* `options` 
+
+### ifAll ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAll.test.js) )
+
+block helper for checking if ALL arguments passed in are truthy
+e.g. {{#ifAll foo bar baz}}all are truthy{{else}}not all are truthy{{/ifAll}}
+
+#### Params
+
+### ifAny ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAny.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAny.test.js) )
+
+block helper for checking if ANY arguments passed in are truthy
+e.g. {{#ifAny foo bar baz}}at least one is truthy{{else}}none are truthy{{/ifAny}}
+
+#### Params
+
+### ifNone ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifNone.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifNone.test.js) )
+
+block helper for checking if NO arguments passed in are truthy
+e.g. {{#ifNone foo bar baz}}all are falsy{{else}}not all are falsy{{/ifNone}}
+
+#### Params
+
+### modulo ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/modulo.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/modulo.test.js) )
 
 _No description_
 
-
-**if** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.test.js) )
-
-_No description_
-
-
-**ifAll** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAll.test.js) )
-
-_No description_
-
-
-**ifAny** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAny.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAny.test.js) )
-
-_No description_
-
-
-**ifNone** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifNone.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifNone.test.js) )
-
-_No description_
-
-
-**modulo** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/modulo.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/modulo.test.js) )
-
-_No description_
 
 
 ## html
 
-**striptags** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/striptags.js) | no tests )
+
+### striptags ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/striptags.js) | no tests )
 
 _No description_
 
 
-**wordCount** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/wordCount.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/wordCount.test.js) )
 
-_No description_
+### wordCount ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/wordCount.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/wordCount.test.js) )
 
+counts the words in a string of text or html
+
+#### Params
+* `html` 
 
 ## misc
 
-**indexOf** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/indexOf.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/indexOf.test.js) )
+
+### indexOf ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/indexOf.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/indexOf.test.js) )
 
 _No description_
 
 
-**set** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.test.js) )
 
-_No description_
+### set ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.test.js) )
 
+set data into current context
+
+#### Params
+* `key` _(string)_ _.set() key/path
+* `val` 
+
+#### Returns
+doesn&#x27;t actually print anything
 
 ## numbers
 
-**addCommas** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.test.js) )
 
-_No description_
+### addCommas ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.test.js) )
 
+add commas to numbers.
+note: this overrides handlebars-helpers&#x27; addCommas helper
+because we want to preserve zeroes in decimals (for money)
+e.g. 1234.50 → 1,234.50 instead of 1,234.5
+note: decimals are only preserved if passed in as a string
+(they don&#x27;t exist in js numbers)
 
-**toK** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.test.js) )
+#### Params
+* `num` 
 
-_No description_
+### toK ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.test.js) )
 
+convert number to shorthand
+e.g. 1000 → 1k
+
+#### Params
+* `x` 
 
 ## objects
 
-**commaSeparated** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/objects/commaSeparated.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/objects/commaSeparated.test.js) )
 
-_No description_
+### commaSeparated ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/objects/commaSeparated.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/objects/commaSeparated.test.js) )
 
+Turn an object into a comma-delineated list of key names,
+based on if their values are true/false
+e.g. { a: true, b: false, c: true } → a, b, c
+
+#### Params
+* `obj` _(object)_ 
+* `shouldCapitalize` _(boolean)_ capitalizes first word in each key
 
 ## strings
 
-**kebabCase** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/kebabCase.js) | no tests )
+
+### kebabCase ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/kebabCase.js) | no tests )
 
 _No description_
 
 
-**longestWord** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.test.js) )
 
-_No description_
+### longestWord ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.test.js) )
 
+returns the number of characters in the longest word of
+a string. Punctuation is NOT ignored.
 
-**randomString** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.test.js) )
+#### Params
+* `str` _(string)_ 
 
-_No description_
+### randomString ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.test.js) )
 
+generatea random string
+e.g. 
+
+#### Params
+* `prefix` 
+* `options` 
 
 ## time
 
-**articleDate** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/articleDate.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/articleDate.test.js) )
 
-_No description_
+### articleDate ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/articleDate.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/articleDate.test.js) )
 
+generate article dates and times
+
+#### Params
+* `datetime` _(Date)_ 
 
 ## urls
 
-**urlencode** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/urls/urlencode.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/urls/urlencode.test.js) )
+
+### urlencode ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/urls/urlencode.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/urls/urlencode.test.js) )
 
 _No description_
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,6 @@ Return the first component (from a list of components) with a truthy  `displaySe
 
 ```
 
----
-
 ### displaySelfAll ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelfAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelfAll.test.js) )
 
 Return all components (from a list of components) with a truthy  `displaySelf`  property. Used by Spaces.
@@ -133,24 +131,28 @@ Return all components (from a list of components) with a truthy  `displaySelf`  
 
 ```
 
----
-
 ### getComponentName ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/getComponentName.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/getComponentName.test.js) )
 
 get a component's name from the reference
 
 #### Params
-* `ref` _(string)_ 
+* `ref` _(string)_ full component uri
 
----
+**Returns** _(string)_ 
+
+#### Example
+
+```hbs
+{{ getComponentName "domain.com/components/foo" }}
+//=> foo
+```
 
 ## conditionals
 
 
 ### compare ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.test.js) )
 
-compare two values, with an operator
-note: if you don't pass an operator, it assumes '==='
+compare two values, with an operator.<br />note: if you don't pass an operator, it assumes '==='
 
 #### Params
 * `left` left value
@@ -158,7 +160,7 @@ note: if you don't pass an operator, it assumes '==='
 * `right` right value
 * `options` 
 
----
+**Returns** _(string)_ 
 
 ### if ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.test.js) )
 
@@ -169,42 +171,37 @@ if
 * `value` to print if conditional is truthy
 * `options` 
 
----
+**Returns** _(string)_ 
 
 ### ifAll ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAll.test.js) )
 
-block helper for checking if ALL arguments passed in are truthy
-e.g. {{#ifAll foo bar baz}}all are truthy{{else}}not all are truthy{{/ifAll}}
+block helper for checking if ALL arguments passed in are truthy<br />e.g. {{#ifAll foo bar baz}}all are truthy{{else}}not all are truthy{{/ifAll}}
 
 #### Params
 
----
+**Returns** _(string)_ 
 
 ### ifAny ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAny.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAny.test.js) )
 
-block helper for checking if ANY arguments passed in are truthy
-e.g. {{#ifAny foo bar baz}}at least one is truthy{{else}}none are truthy{{/ifAny}}
+block helper for checking if ANY arguments passed in are truthy<br />e.g. {{#ifAny foo bar baz}}at least one is truthy{{else}}none are truthy{{/ifAny}}
 
 #### Params
 
----
+**Returns** _(string)_ 
 
 ### ifNone ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifNone.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifNone.test.js) )
 
-block helper for checking if NO arguments passed in are truthy
-e.g. {{#ifNone foo bar baz}}all are falsy{{else}}not all are falsy{{/ifNone}}
+block helper for checking if NO arguments passed in are truthy<br />e.g. {{#ifNone foo bar baz}}all are falsy{{else}}not all are falsy{{/ifNone}}
 
 #### Params
 
----
+**Returns** _(string)_ 
 
 ### modulo ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/modulo.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/modulo.test.js) )
 
 _No description_
 
 
-
----
 
 ## html
 
@@ -215,8 +212,6 @@ _No description_
 
 
 
----
-
 ### wordCount ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/wordCount.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/wordCount.test.js) )
 
 counts the words in a string of text or html
@@ -224,7 +219,7 @@ counts the words in a string of text or html
 #### Params
 * `html` 
 
----
+**Returns** _(string)_ 
 
 ## misc
 
@@ -234,8 +229,6 @@ counts the words in a string of text or html
 _No description_
 
 
-
----
 
 ### set ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.test.js) )
 
@@ -247,15 +240,12 @@ set data into current context
 
 **Returns** _(string)_ doesn't actually print anything
 
----
-
 ## numbers
 
 
 ### addCommas ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.test.js) )
 
-add commas to numbers.
-note: this overrides handlebars-helpers' addCommas helper
+add commas to numbers.<br />note: this overrides handlebars-helpers' addCommas helper
 because we want to preserve zeroes in decimals (for money)
 e.g. 1234.50 → 1,234.50 instead of 1,234.5
 note: decimals are only preserved if passed in as a string
@@ -264,32 +254,30 @@ note: decimals are only preserved if passed in as a string
 #### Params
 * `num` 
 
----
+**Returns** _(string)_ 
 
 ### toK ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.test.js) )
 
-convert number to shorthand
-e.g. 1000 → 1k
+convert number to shorthand<br />e.g. 1000 → 1k
 
 #### Params
 * `x` 
 
----
+**Returns** _(string)_ 
 
 ## objects
 
 
 ### commaSeparated ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/objects/commaSeparated.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/objects/commaSeparated.test.js) )
 
-Turn an object into a comma-delineated list of key names,
-based on if their values are true/false
+Turn an object into a comma-delineated list of key names,<br />based on if their values are true/false
 e.g. { a: true, b: false, c: true } → a, b, c
 
 #### Params
 * `obj` _(object)_ 
 * `shouldCapitalize` _(boolean)_ capitalizes first word in each key
 
----
+**Returns** _(string)_ 
 
 ## strings
 
@@ -300,29 +288,25 @@ _No description_
 
 
 
----
-
 ### longestWord ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.test.js) )
 
-returns the number of characters in the longest word of
-a string. Punctuation is NOT ignored.
+returns the number of characters in the longest word of<br />a string. Punctuation is NOT ignored.
 
 #### Params
 * `str` _(string)_ 
 
----
+**Returns** _(number)_ 
 
 ### randomString ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.test.js) )
 
-generatea random string
-e.g.  `greatest-hit-`  →  `greatest-hit-noctz56h` 
+generatea random string<br />e.g.  `greatest-hit-`  →  `greatest-hit-noctz56h` 
 note: allows passing length=x to generate strings of different lengths
 
 #### Params
 * `prefix` 
 * `options` 
 
----
+**Returns** _(string)_ 
 
 ## time
 
@@ -334,7 +318,7 @@ generate article dates and times
 #### Params
 * `datetime` _(Date)_ 
 
----
+**Returns** _(string)_ 
 
 ## urls
 
@@ -344,8 +328,6 @@ generate article dates and times
 _No description_
 
 
-
----
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ generate a random string<br /> _note:_  by default it generates an 8-character s
 
 ### articleDate ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/articleDate.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/articleDate.test.js) )
 
-generate article dates and times
+generate article dates and times, based on a relative format
 
 #### Params
 * `datetime` _(Date|string)_ for  `moment.js`  to parse
@@ -459,9 +459,19 @@ generate article dates and times
 
 ### urlencode ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/urls/urlencode.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/urls/urlencode.test.js) )
 
-_No description_
+encode urls (ported from the nunjucks  `urlencode`  filter)<br /> _note:_   `handlebars-helpers`  contains an  `encodeURI`  helper, but it doesn't handle arrays or objects.
 
+#### Params
+* `obj` _(*)_ data to encode
 
+**Returns** _(string)_ urlencoded data
+
+#### Example
+
+```hbs
+{{ urlencode "&" }}
+//=> "%26"
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -101,13 +101,12 @@ Currently **21 helpers** in **9 categories**:
 
 ### displaySelf ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelf.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelf.test.js) )
 
-Return the first component (from a list of components) with a truthy displaySelf property. Used by Spaces.
+Return the first component (from a list of components) with a truthy  `displaySelf`  property. Used by Spaces.
 
 #### Params
-* `components` _(array)_ with displaySelf properties
+* `components` _(array)_ with  `displaySelf`  properties
 
-#### Returns
-first component with displaySelf: true
+**Returns** _(object)_ first component with  `displaySelf: true`
 
 #### Example
 
@@ -116,18 +115,34 @@ first component with displaySelf: true
 
 ```
 
+---
+
 ### displaySelfAll ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelfAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelfAll.test.js) )
 
-_No description_
+Return all components (from a list of components) with a truthy  `displaySelf`  property. Used by Spaces.
 
+#### Params
+* `components` _(array)_ with  `displaySelf`  properties
 
+**Returns** _(array)_ all components with  `displaySelf: true`
+
+#### Example
+
+```hbs
+{{> component-list (displaySelfAll content) }}
+
+```
+
+---
 
 ### getComponentName ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/getComponentName.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/getComponentName.test.js) )
 
-get a component&#x27;s name from the reference
+get a component's name from the reference
 
 #### Params
 * `ref` _(string)_ 
+
+---
 
 ## conditionals
 
@@ -135,13 +150,15 @@ get a component&#x27;s name from the reference
 ### compare ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.test.js) )
 
 compare two values, with an operator
-note: if you don&#x27;t pass an operator, it assumes &#x27;&#x3D;&#x3D;&#x3D;&#x27;
+note: if you don't pass an operator, it assumes '==='
 
 #### Params
 * `left` left value
 * `operator` _(string)_ 
 * `right` right value
 * `options` 
+
+---
 
 ### if ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.test.js) )
 
@@ -152,12 +169,16 @@ if
 * `value` to print if conditional is truthy
 * `options` 
 
+---
+
 ### ifAll ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAll.test.js) )
 
 block helper for checking if ALL arguments passed in are truthy
 e.g. {{#ifAll foo bar baz}}all are truthy{{else}}not all are truthy{{/ifAll}}
 
 #### Params
+
+---
 
 ### ifAny ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAny.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAny.test.js) )
 
@@ -166,6 +187,8 @@ e.g. {{#ifAny foo bar baz}}at least one is truthy{{else}}none are truthy{{/ifAny
 
 #### Params
 
+---
+
 ### ifNone ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifNone.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifNone.test.js) )
 
 block helper for checking if NO arguments passed in are truthy
@@ -173,11 +196,15 @@ e.g. {{#ifNone foo bar baz}}all are falsy{{else}}not all are falsy{{/ifNone}}
 
 #### Params
 
+---
+
 ### modulo ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/modulo.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/modulo.test.js) )
 
 _No description_
 
 
+
+---
 
 ## html
 
@@ -188,12 +215,16 @@ _No description_
 
 
 
+---
+
 ### wordCount ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/wordCount.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/wordCount.test.js) )
 
 counts the words in a string of text or html
 
 #### Params
 * `html` 
+
+---
 
 ## misc
 
@@ -204,6 +235,8 @@ _No description_
 
 
 
+---
+
 ### set ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.test.js) )
 
 set data into current context
@@ -212,8 +245,9 @@ set data into current context
 * `key` _(string)_ _.set() key/path
 * `val` 
 
-#### Returns
-doesn&#x27;t actually print anything
+**Returns** _(string)_ doesn't actually print anything
+
+---
 
 ## numbers
 
@@ -221,14 +255,16 @@ doesn&#x27;t actually print anything
 ### addCommas ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.test.js) )
 
 add commas to numbers.
-note: this overrides handlebars-helpers&#x27; addCommas helper
+note: this overrides handlebars-helpers' addCommas helper
 because we want to preserve zeroes in decimals (for money)
 e.g. 1234.50 → 1,234.50 instead of 1,234.5
 note: decimals are only preserved if passed in as a string
-(they don&#x27;t exist in js numbers)
+(they don't exist in js numbers)
 
 #### Params
 * `num` 
+
+---
 
 ### toK ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.test.js) )
 
@@ -237,6 +273,8 @@ e.g. 1000 → 1k
 
 #### Params
 * `x` 
+
+---
 
 ## objects
 
@@ -251,6 +289,8 @@ e.g. { a: true, b: false, c: true } → a, b, c
 * `obj` _(object)_ 
 * `shouldCapitalize` _(boolean)_ capitalizes first word in each key
 
+---
+
 ## strings
 
 
@@ -260,6 +300,8 @@ _No description_
 
 
 
+---
+
 ### longestWord ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.test.js) )
 
 returns the number of characters in the longest word of
@@ -268,14 +310,19 @@ a string. Punctuation is NOT ignored.
 #### Params
 * `str` _(string)_ 
 
+---
+
 ### randomString ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.test.js) )
 
 generatea random string
-e.g. 
+e.g.  `greatest-hit-`  →  `greatest-hit-noctz56h` 
+note: allows passing length=x to generate strings of different lengths
 
 #### Params
 * `prefix` 
 * `options` 
+
+---
 
 ## time
 
@@ -287,6 +334,8 @@ generate article dates and times
 #### Params
 * `datetime` _(Date)_ 
 
+---
+
 ## urls
 
 
@@ -295,6 +344,8 @@ generate article dates and times
 _No description_
 
 
+
+---
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ get a component's name from the reference
 
 ### compare ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/compare.test.js) )
 
-compare two values, with an operator.<br />note: if you don't pass an operator, it assumes  `===` <br />note: this can be used as a block  _or_  inline helper
+compare two values, with an operator.<br /> _note:_  if you don't pass an operator, it assumes  `===` <br /> _note:_  this can be used as a block  _or_  inline helper
 
 #### Params
 * `left` _(*)_ left value
@@ -166,58 +166,118 @@ compare two values, with an operator.<br />note: if you don't pass an operator, 
 
 ```hbs
 {{ compare 10 ">" 5 }}
-//=> &quot;true&quot;
+//=> "true"
 ```
 
 ### if ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/if.test.js) )
 
-if
+overwrite default handlebars 'if' helper<br />this adds support for an inline helper,  `{{if foo bar}}`   _(if foo is truthy, print bar)_ <br />as well as an inline if/else helper,  `{{if foo bar else=baz}}`   _(if foo is truthy, print bar. otherwise, print baz)_
 
 #### Params
 * `conditional` _(*)_ to check for truthiness
 * `value` _(*)_ to print if conditional is truthy
 * `[options]` _(object)_ 
 
-**Returns** _(string)_ 
+**Returns** _(string)_ if inline, otherwise calls block functions
+
+#### Example
+
+```hbs
+{{ if true "bar" else="baz" }}
+//=> "bar"
+```
 
 ### ifAll ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAll.test.js) )
 
-block helper for checking if ALL arguments passed in are truthy<br />e.g. {{#ifAll foo bar baz}}all are truthy{{else}}not all are truthy{{/ifAll}}
+block helper for checking if ALL arguments passed in are truthy
 
-#### Params
 
-**Returns** _(string)_ 
+
+**Returns** _(string)_ calls block functions
+
+#### Example
+
+```hbs
+{{#ifAll foo bar baz}}
+  all are truthy
+{{else}}
+  not all are truthy
+{{/ifAll}}
+
+```
 
 ### ifAny ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAny.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifAny.test.js) )
 
-block helper for checking if ANY arguments passed in are truthy<br />e.g. {{#ifAny foo bar baz}}at least one is truthy{{else}}none are truthy{{/ifAny}}
+block helper for checking if ANY arguments passed in are truthy
 
-#### Params
 
-**Returns** _(string)_ 
+
+**Returns** _(string)_ calls block functions
+
+#### Example
+
+```hbs
+{{#ifAny foo bar baz}}
+  at least one is truthy
+{{else}}
+  none are truthy
+{{/ifAny}}
+
+```
 
 ### ifNone ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifNone.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/ifNone.test.js) )
 
-block helper for checking if NO arguments passed in are truthy<br />e.g. {{#ifNone foo bar baz}}all are falsy{{else}}not all are falsy{{/ifNone}}
+block helper for checking if NO arguments passed in are truthy
 
-#### Params
 
-**Returns** _(string)_ 
+
+**Returns** _(string)_ calls block functions
+
+#### Example
+
+```hbs
+{{#ifNone foo bar baz}}
+  all are falsy
+{{else}}
+  not all are falsy
+{{/ifNone}}
+
+```
 
 ### modulo ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/modulo.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/conditionals/modulo.test.js) )
 
-_No description_
+compare the modulo of two values to a third value
 
+#### Params
+* `dividend` _(number)_ 
+* `divisor` _(number)_ 
+* `remainder` _(number)_ 
+* `[options]` _(object)_ 
 
+**Returns** _(string)_ if inline, otherwise calls block functions
+
+#### Example
+
+```hbs
+{{modulo 3 2 1}}
+//=> true
+```
 
 ## html
 
 
 ### striptags ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/striptags.js) | no tests )
 
-_No description_
+straight passthrough to striptags
 
 
+
+#### Example
+
+```hbs
+{{ striptags "<p><b>Hello</b> <em>World!</em></p>" }}
+//=> Hello World!
+```
 
 ### wordCount ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/wordCount.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/html/wordCount.test.js) )
 
@@ -226,54 +286,91 @@ counts the words in a string of text or html
 #### Params
 * `[html]` _(string)_ 
 
-**Returns** _(string)_ 
+**Returns** _(number)_ the number of words
+
+#### Example
+
+```hbs
+{{wordCount "<div> This is <b> cool </b> </div>"}}
+//=> 3
+```
 
 ## misc
 
 
 ### indexOf ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/indexOf.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/indexOf.test.js) )
 
-_No description_
+get the index of something inside something else
 
+#### Params
+* `outside` _(*)_ array, string, etc (anything with  `indexOf` )
+* `inside` _(*)_ anything that can exist inside something else
 
+**Returns** _(number)_ 
+
+#### Example
+
+```hbs
+{{ indexOf "foo" "o" }}
+//=> 1
+```
 
 ### set ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.test.js) )
 
-set data into current context
+set data into current context<br /> _note:_  doesn't return anything
 
 #### Params
-* `key` _(string)_ _.set() key/path
-* `val` _(*)_ 
+* `key` _(string)_ `_.set()`  key/path
+* `val` _(*)_ value to set
 
-**Returns** _(string)_ doesn't actually print anything
+#### Example
+
+```hbs
+{{ set "a.b.c" "abc" }}{{ a.b.c }}
+//=> "abc"
+```
 
 ## numbers
 
 
 ### addCommas ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.test.js) )
 
-add commas to numbers.<br />note: this overrides handlebars-helpers' addCommas helper<br />because we want to preserve zeroes in decimals (for money)<br />e.g. 1234.50 → 1,234.50 instead of 1,234.5<br />note: decimals are only preserved if passed in as a string<br />(they don't exist in js numbers)
+add commas to numbers.<br /> _note:_  this overrides handlebars-helpers'  `addCommas`  helper because we want to preserve zeroes in decimals (for money)<br />e.g.  `1234.50`  →  `1,234.50`  instead of  `1,234.5` <br /> _note:_  decimals are only preserved if passed in as a string (they don't exist in js numbers)
 
 #### Params
 * `num` _(number|string)_ 
 
 **Returns** _(string)_ 
 
+#### Example
+
+```hbs
+{{ addCommas "1234.50" }}
+//=> "1,234.50"
+```
+
 ### toK ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.test.js) )
 
-convert number to shorthand<br />e.g. 1000 → 1k
+format thousands using  `k` <br />e.g.  `1000`  →  `1k`
 
 #### Params
-* `x` _(number|string)_ 
+* `x` _(number|string)_ number to format
 
 **Returns** _(string)_ 
+
+#### Example
+
+```hbs
+{{ toK 1234.5 }}
+//=> "1.2k"
+```
 
 ## objects
 
 
 ### commaSeparated ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/objects/commaSeparated.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/objects/commaSeparated.test.js) )
 
-Turn an object into a comma-delineated list of key names,<br />based on if their values are true/false<br />e.g. { a: true, b: false, c: true } → a, b, c
+Turn an object into a comma-delineated list of key names, depending if their values are true/false
 
 #### Params
 * `obj` _(object)_ 
@@ -281,33 +378,62 @@ Turn an object into a comma-delineated list of key names,<br />based on if their
 
 **Returns** _(string)_ 
 
+#### Example
+
+```hbs
+{{ commaSeparated {alpha: true, "bravo charlie": true} true }}
+//=> "Alpha, Bravo charlie"
+```
+
 ## strings
 
 
 ### kebabCase ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/kebabCase.js) | no tests )
 
-_No description_
+straight passthrough to  `_.kebabCase`
 
 
+
+#### Example
+
+```hbs
+{{ kebabCase "Foo Bar Baz" }}
+//=> "foo-bar-baz"
+```
 
 ### longestWord ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.test.js) )
 
-returns the number of characters in the longest word of<br />a string. Punctuation is NOT ignored.
+returns the number of characters in the longest word of a string. Punctuation is NOT ignored.
 
 #### Params
-* `str` _(string)_ 
+* `str` _(string)_ string to search through
 
-**Returns** _(number)_ 
+**Returns** _(number)_ of letters in the longest word
+
+#### Example
+
+```hbs
+{{ longestWord "Foo Ba b" }}
+//=> 3
+```
 
 ### randomString ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.test.js) )
 
-generatea random string<br />e.g.  `greatest-hit-`  →  `greatest-hit-noctz56h` <br />note: allows passing length=x to generate strings of different lengths
+generate a random string<br /> _note:_  by default it generates an 8-character string
 
 #### Params
-* `[prefix]` _(string)_ 
+* `[prefix]` _(string)_ string to append random stuff to
 * `[options]` _(object)_ 
+* `[options.hash.characters]` _(number)_ generate string of a custom length
 
 **Returns** _(string)_ 
+
+#### Example
+
+```hbs
+{{ randomString "greatest-hit-" characters=3 }}
+//=> "greatest-hit-z56"
+```
 
 ## time
 
@@ -317,9 +443,16 @@ generatea random string<br />e.g.  `greatest-hit-`  →  `greatest-hit-noctz56h`
 generate article dates and times
 
 #### Params
-* `datetime` _(Date)_ 
+* `datetime` _(Date|string)_ for  `moment.js`  to parse
 
 **Returns** _(string)_ 
+
+#### Example
+
+```hbs
+{{ articleDate "Fri, 13 Jan 2017 18:22:16 GMT" }}
+//=> "Yesterday at 6:22 p.m."
+```
 
 ## urls
 

--- a/docs/categorySection.hbs
+++ b/docs/categorySection.hbs
@@ -1,0 +1,7 @@
+{{#each this}}
+## {{ name }}
+
+{{#each helpers}}
+{{> details }}
+{{/each}}
+{{/each}}

--- a/docs/categorySection.hbs
+++ b/docs/categorySection.hbs
@@ -1,4 +1,5 @@
 {{#each this}}
+
 ## {{ name }}
 
 {{#each helpers}}

--- a/docs/details.hbs
+++ b/docs/details.hbs
@@ -1,0 +1,16 @@
+**{{ name }}** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/{{ category }}/{{ name }}.js) | {{#if hasTestFile}}[tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/{{ category }}/{{ name }}.test.js){{else}}no tests{{/if}} )
+
+{{ default description '_No description_' }}
+
+{{#if params}}#### Params{{/if}}
+{{#each params}}
+* `{{ name }}` **{{ type }}** {{ description }}
+{{/each}}
+{{#if code}}
+#### Example
+
+```
+{{ code }}
+//=> {{ result }}
+```
+{{/if}}

--- a/docs/details.hbs
+++ b/docs/details.hbs
@@ -3,7 +3,7 @@
 
 {{{ default description '_No description_' }}}
 
-{{#if params}}#### Params{{/if}}
+{{#if params.length}}#### Params{{/if}}
 {{#each params}}
 * `{{ if isOptional '[' }}{{ name }}{{ if isOptional ']' }}` {{#if type}}_({{ type }})_ {{/if}}{{{ description }}}
 {{/each}}
@@ -17,6 +17,6 @@
 
 ```hbs
 {{{ code }}}
-{{#if result}}//=> {{ result }}{{/if}}
+{{#if result}}//=> {{{ result }}}{{/if}}
 ```
 {{/ifAny}}

--- a/docs/details.hbs
+++ b/docs/details.hbs
@@ -1,16 +1,23 @@
-**{{ name }}** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/{{ category }}/{{ name }}.js) | {{#if hasTestFile}}[tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/{{ category }}/{{ name }}.test.js){{else}}no tests{{/if}} )
+
+### {{ name }} ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/{{ category }}/{{ name }}.js) | {{#if hasTestFile}}[tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/{{ category }}/{{ name }}.test.js){{else}}no tests{{/if}} )
 
 {{ default description '_No description_' }}
 
 {{#if params}}#### Params{{/if}}
 {{#each params}}
-* `{{ name }}` **{{ type }}** {{ description }}
+* `{{ name }}` {{#if type}}_({{ type }})_ {{/if}}{{ description }}
 {{/each}}
-{{#if code}}
+{{#if returnValue}}
+
+#### Returns
+{{ returnValue }}
+{{/if}}
+{{#ifAny code result}}
+
 #### Example
 
+```hbs
+{{{ code }}}
+{{#if result}}//=> {{ result }}{{/if}}
 ```
-{{ code }}
-//=> {{ result }}
-```
-{{/if}}
+{{/ifAny}}

--- a/docs/details.hbs
+++ b/docs/details.hbs
@@ -7,10 +7,10 @@
 {{#each params}}
 * `{{ name }}` {{#if type}}_({{ type }})_ {{/if}}{{{ description }}}
 {{/each}}
-{{#if returnValue}}
+{{#ifAny returnValue returnType}}
 
 **Returns** {{#if returnType}}_({{ returnType }})_ {{/if}}{{{ returnValue }}}
-{{/if}}
+{{/ifAny}}
 {{#ifAny code result}}
 
 #### Example

--- a/docs/details.hbs
+++ b/docs/details.hbs
@@ -5,7 +5,7 @@
 
 {{#if params}}#### Params{{/if}}
 {{#each params}}
-* `{{ name }}` {{#if type}}_({{ type }})_ {{/if}}{{{ description }}}
+* `{{ if isOptional '[' }}{{ name }}{{ if isOptional ']' }}` {{#if type}}_({{ type }})_ {{/if}}{{{ description }}}
 {{/each}}
 {{#ifAny returnValue returnType}}
 

--- a/docs/details.hbs
+++ b/docs/details.hbs
@@ -1,16 +1,15 @@
 
 ### {{ name }} ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/{{ category }}/{{ name }}.js) | {{#if hasTestFile}}[tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/{{ category }}/{{ name }}.test.js){{else}}no tests{{/if}} )
 
-{{ default description '_No description_' }}
+{{{ default description '_No description_' }}}
 
 {{#if params}}#### Params{{/if}}
 {{#each params}}
-* `{{ name }}` {{#if type}}_({{ type }})_ {{/if}}{{ description }}
+* `{{ name }}` {{#if type}}_({{ type }})_ {{/if}}{{{ description }}}
 {{/each}}
 {{#if returnValue}}
 
-#### Returns
-{{ returnValue }}
+**Returns** {{#if returnType}}_({{ returnType }})_ {{/if}}{{{ returnValue }}}
 {{/if}}
 {{#ifAny code result}}
 

--- a/docs/generate-readme.js
+++ b/docs/generate-readme.js
@@ -13,24 +13,34 @@ function noTests(filename) {
   return filename.indexOf('.test.js') === -1;
 }
 
+function parseDoc(block) {
+  return block.type === 'inlineCode' ? '`' + block.value + '`' : block.value;
+}
+
 function generateDoc(helper) {
   const rawDoc = doc.buildSync([helper], { shallow: true })[0];
 
   if (!_.isEmpty(rawDoc)) {
-    let description = _.get(rawDoc, 'description.children[0].children[0].value'),
+    let desc = _.get(rawDoc, 'description.children[0].children') || [],
+      ret = _.get(rawDoc, 'returns[0].description.children[0].children') || [],
+      returnType = _.get(rawDoc, 'returns[0].type.name'),
+      description = desc.map(parseDoc).join(' '),
       params = _.map(rawDoc.params, function (param) {
+        let desc = _.get(param, 'description.children[0].children') || [];
+
         return {
           name: param.name,
           type: _.get(param, 'type.name'),
-          description: _.get(param, 'description.children[0].children[0].value')
+          description: desc.map(parseDoc).join(' ')
         };
       }),
-      returnValue = _.get(rawDoc, 'returns[0].description.children[0].children[0].value');
+      returnValue = ret.map(parseDoc).join(' ');
 
     return {
       description,
       params,
-      returnValue
+      returnValue,
+      returnType
     };
   } else {
     return {};

--- a/docs/generate-readme.js
+++ b/docs/generate-readme.js
@@ -13,6 +13,11 @@ function noTests(filename) {
   return filename.indexOf('.test.js') === -1;
 }
 
+/**
+ * parse jsdoc descriptions for code blocks and such
+ * @param  {object} block
+ * @return {string}
+ */
 function parseDoc(block) {
   return block.type === 'inlineCode' ? '`' + block.value + '`' : block.value;
 }
@@ -24,7 +29,7 @@ function generateDoc(helper) {
     let desc = _.get(rawDoc, 'description.children[0].children') || [],
       ret = _.get(rawDoc, 'returns[0].description.children[0].children') || [],
       returnType = _.get(rawDoc, 'returns[0].type.name'),
-      description = desc.map(parseDoc).join(' '),
+      description = desc.map(parseDoc).join(' ').replace('\n', '<br />'),
       params = _.map(rawDoc.params, function (param) {
         let desc = _.get(param, 'description.children[0].children') || [];
 

--- a/docs/generate-readme.js
+++ b/docs/generate-readme.js
@@ -1,0 +1,80 @@
+'use strict';
+const hbs = require('../.')(),
+  _ = require('lodash'),
+  path = require('path'),
+  fs = require('fs'),
+  chalk = require('chalk'),
+  glob = require('glob');
+
+let tpl, data;
+
+function noTests(filename) {
+  return filename.indexOf('.test.js') === -1;
+}
+
+function reduceHelpers(category) {
+  return function (result, helper) {
+    const info = _.assign({
+      name: path.basename(helper, '.js'),
+      hasTestFile: fs.existsSync(helper.replace('.js', '.test.js')),
+      category: category
+    }, require(helper).info || {});
+
+    result.push(info);
+    return result;
+  };
+}
+
+/**
+ * generate category data
+ * @param  {array} result
+ * @param  {array} category directory name
+ * @return {array}
+ */
+function reduceCategories(result, category) {
+  const dir = path.join(__dirname, '..', 'helpers', category);
+
+  if (fs.statSync(dir).isDirectory()) {
+    result.push({
+      name: category,
+      helpers: _.reduce(glob.sync(path.join(dir, '*.js')).filter(noTests), reduceHelpers(category), [])
+    });
+  }
+
+  return result;
+}
+
+/**
+ * generate partial data
+ * @param  {array} result
+ * @param  {string} partial
+ * @return {array}
+ */
+function reducePartials(result, partial) {
+  result.push({
+    name: path.basename(partial, '.hbs'),
+    hasTestFile: fs.existsSync(partial.replace('.hbs', '.test.js'))
+  });
+  return result;
+}
+
+// register all docs partials
+_.each([
+  'categorySection',
+  'details',
+  'toc'
+], function (basename) {
+  hbs.registerPartial(basename, require(`./${basename}.hbs`));
+});
+
+// get the helpers and partials
+data = {
+  categories: _.reduce(fs.readdirSync(path.join(__dirname, '..', 'helpers')), reduceCategories, []),
+  totalHelpers: glob.sync(path.resolve(__dirname, '..', 'helpers', '**', '*.js')).filter(noTests).length,
+  partials: _.reduce(glob.sync(path.resolve(__dirname, '..', 'partials', '*.hbs')), reducePartials, [])
+};
+
+// compile the template and run it
+tpl = hbs.compile(fs.readFileSync(path.join(__dirname, 'readme.hbs'), 'utf8'));
+fs.writeFileSync(path.join(__dirname, '..', 'README.md'), tpl(data));
+console.log(`${chalk.green('[DONE]')} Generated readme`);

--- a/docs/generate-readme.js
+++ b/docs/generate-readme.js
@@ -19,7 +19,16 @@ function noTests(filename) {
  * @return {string}
  */
 function parseDoc(block) {
-  return block.type === 'inlineCode' ? '`' + block.value + '`' : block.value;
+  if (block.type === 'inlineCode') {
+    return '`' + block.value + '`';
+  } else if (block.type === 'emphasis') {
+    return `_${block.children.map(parseDoc).join(' ')}_`;
+  } else if (block.type === 'text') {
+    return block.value;
+  } else {
+    // you should tell a dev, because we don't know what we're dealing with here
+    throw new Error(`Unknown text block type "${block.type}"!`);
+  }
 }
 
 /**
@@ -42,7 +51,7 @@ function parseType(obj) {
     return _.map(obj.elements, (el) => parseType(el)).join('|');
   } else {
     // you should tell a dev, because we don't know what we're dealing with here
-    throw new Error(`Unknown type "${obj.type}"!`);
+    throw new Error(`Unknown param type "${obj.type}"!`);
   }
 }
 
@@ -53,7 +62,7 @@ function generateDoc(helper) {
     let desc = _.get(rawDoc, 'description.children[0].children') || [],
       ret = _.get(rawDoc, 'returns[0].description.children[0].children') || [],
       returnType = _.get(rawDoc, 'returns[0].type.name'),
-      description = desc.map(parseDoc).join(' ').replace('\n', '<br />'),
+      description = desc.map(parseDoc).join(' ').replace(/\n/g, '<br />'),
       params = _.map(rawDoc.params, function (param) {
         let desc = _.get(param, 'description.children[0].children') || [];
 

--- a/docs/readme.hbs
+++ b/docs/readme.hbs
@@ -1,0 +1,69 @@
+# nymag-handlebars
+
+[![Build Status](https://travis-ci.org/nymag/nymag-handlebars.svg)](https://travis-ci.org/nymag/nymag-handlebars)
+[![Coverage Status](https://coveralls.io/repos/github/nymag/nymag-handlebars/badge.svg?branch=master)](https://coveralls.io/github/nymag/nymag-handlebars?branch=master)
+[![Code Climate](https://codeclimate.com/github/nymag/nymag-handlebars/badges/gpa.svg)](https://codeclimate.com/github/nymag/nymag-handlebars)
+
+A collection of helpers and partials for handlebars
+
+# Installation
+
+```
+npm install --save nymag-handlebars
+```
+
+# Usage
+
+By default, `nymag-handlebars` will export a function that returns a new handlebars instance with all of the helpers and partials added.
+
+```js
+var hbs = require('nymag-handlebars')(),
+  template = hbs.compile('&lt;h1&gt;Hello \{{ place }}!&lt;/h1&gt;'),
+  result = template({ place: 'World' });
+
+// result: &lt;h1&gt;Hello World!&lt;/h1&gt;
+```
+
+## Passing env in
+
+If you want to configure and use your own handlebars environment, you can pass it through
+
+```js
+var Handlebars = require('express-handlebars'),
+  env = new Handlebars({ /* some config */ }),
+  hbs = require('nymag-handlebars')(env),
+  app = require('express')();
+
+app.engine('handlebars', hbs.engine);
+app.set('view engine', 'handlebars');
+```
+
+---
+
+# Helpers
+
+Currently **{{default totalHelpers '0'}} helpers** in **{{default categories.length '0'}} categories**:
+
+{{> toc categories}}
+
+---
+
+{{> categorySection categories}}
+
+---
+
+# Partials
+
+Currently **{{partials.length}} partial{{#compare partials.length '>' 1 }}s{{/compare}}**:
+
+{{#each partials}}
+* **{{ name }}** ( [code](https://github.com/nymag/nymag-handlebars/blob/master/partials/{{ name }}.hbs) | {{#if hasTestFile}}[tests](https://github.com/nymag/nymag-handlebars/blob/master/partials/{{ name }}.test.js){{else}}no tests{{/if}} )
+{{/each}}
+
+---
+
+# Contributing
+
+Pull requests and stars are always welcome. For bugs and feature requests, [please create an issue](https://github.com/nymag/nymag-handlebars/issues/new).
+
+This project is released under the [MIT license](https://github.com/nymag/nymag-handlebars/blob/master/LICENSE).

--- a/docs/toc.hbs
+++ b/docs/toc.hbs
@@ -1,7 +1,8 @@
 {{#each this}}
+
 ### {{ name }}
 
 {{#each helpers}}
-* [{{ name }}](https://github.com/nymag/nymag-handlebars#{{ name }})
+* [**{{ name }}**](https://github.com/nymag/nymag-handlebars#{{ name }}) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/{{ category }}/{{ name }}.js) | {{#if hasTestFile}}[tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/{{ category }}/{{ name }}.test.js){{else}}no tests{{/if}} )
 {{/each}}
 {{/each}}

--- a/docs/toc.hbs
+++ b/docs/toc.hbs
@@ -1,0 +1,7 @@
+{{#each this}}
+### {{ name }}
+
+{{#each helpers}}
+* [{{ name }}](https://github.com/nymag/nymag-handlebars#{{ name }})
+{{/each}}
+{{/each}}

--- a/helpers/components/displaySelf.js
+++ b/helpers/components/displaySelf.js
@@ -1,6 +1,11 @@
 'use strict';
 const _ = require('lodash');
 
+/**
+ * Return the first component (from a list of components) with a truthy displaySelf property. Used by Spaces.
+ * @param  {array} components with displaySelf properties
+ * @return {object} first component with displaySelf: true
+ */
 module.exports = function (components) {
   var limitReached = false;
 
@@ -10,4 +15,8 @@ module.exports = function (components) {
       return item;
     }
   });
+};
+
+module.exports.example = {
+  code: '{{> component-list (displaySelf content) }}'
 };

--- a/helpers/components/displaySelf.js
+++ b/helpers/components/displaySelf.js
@@ -2,9 +2,9 @@
 const _ = require('lodash');
 
 /**
- * Return the first component (from a list of components) with a truthy displaySelf property. Used by Spaces.
- * @param  {array} components with displaySelf properties
- * @return {object} first component with displaySelf: true
+ * Return the first component (from a list of components) with a truthy `displaySelf` property. Used by Spaces.
+ * @param  {array} components with `displaySelf` properties
+ * @return {object} first component with `displaySelf: true`
  */
 module.exports = function (components) {
   var limitReached = false;

--- a/helpers/components/displaySelfAll.js
+++ b/helpers/components/displaySelfAll.js
@@ -1,6 +1,15 @@
 'use strict';
 const _ = require('lodash');
 
+/**
+ * Return all components (from a list of components) with a truthy `displaySelf` property. Used by Spaces.
+ * @param  {array} components with `displaySelf` properties
+ * @return {array} all components with `displaySelf: true`
+ */
 module.exports = function (components) {
   return _.filter(components, item => item.displaySelf);
+};
+
+module.exports.example = {
+  code: '{{> component-list (displaySelfAll content) }}'
 };

--- a/helpers/components/getComponentName.js
+++ b/helpers/components/getComponentName.js
@@ -1,11 +1,16 @@
 'use strict';
 /**
  * get a component's name from the reference
- * @param  {string} ref
+ * @param  {string} ref full component uri
  * @return {string}
  */
 module.exports = function (ref) {
   var result = /components\/(.+?)[\/\.]/.exec(ref) || /components\/(.*)/.exec(ref);
 
   return result && result[1];
+};
+
+module.exports.example = {
+  code: '{{ getComponentName "domain.com/components/foo" }}',
+  result: 'foo'
 };

--- a/helpers/conditionals/compare.js
+++ b/helpers/conditionals/compare.js
@@ -12,6 +12,7 @@ const operators = {
 /**
  * compare two values, with an operator.
  * note: if you don't pass an operator, it assumes `===`
+ * note: this can be used as a block _or_ inline helper
  * @param  {*} left     left value
  * @param  {string} operator to compare with
  * @param  {*} right    right value
@@ -44,4 +45,9 @@ module.exports = function (left, operator, right, options) {
   } else {
     return options.inverse ? options.inverse(this) : '';
   }
+};
+
+module.exports.example = {
+  code: '{{ compare 10 ">" 5 }}',
+  result: '"true"'
 };

--- a/helpers/conditionals/compare.js
+++ b/helpers/conditionals/compare.js
@@ -11,8 +11,8 @@ const operators = {
 
 /**
  * compare two values, with an operator.
- * note: if you don't pass an operator, it assumes `===`
- * note: this can be used as a block _or_ inline helper
+ * _note:_ if you don't pass an operator, it assumes `===`
+ * _note:_ this can be used as a block _or_ inline helper
  * @param  {*} left     left value
  * @param  {string} operator to compare with
  * @param  {*} right    right value

--- a/helpers/conditionals/compare.js
+++ b/helpers/conditionals/compare.js
@@ -10,7 +10,7 @@ const operators = {
 };
 
 /**
- * compare two values, with an operator
+ * compare two values, with an operator.
  * note: if you don't pass an operator, it assumes '==='
  * @param  {*} left     left value
  * @param  {string} operator

--- a/helpers/conditionals/compare.js
+++ b/helpers/conditionals/compare.js
@@ -11,12 +11,12 @@ const operators = {
 
 /**
  * compare two values, with an operator.
- * note: if you don't pass an operator, it assumes '==='
+ * note: if you don't pass an operator, it assumes `===`
  * @param  {*} left     left value
- * @param  {string} operator
+ * @param  {string} operator to compare with
  * @param  {*} right    right value
  * @param  {object} [options]
- * @return {string}
+ * @return {string} if inline, otherwise calls block functions
  */
 module.exports = function (left, operator, right, options) {
   let result;

--- a/helpers/conditionals/if.js
+++ b/helpers/conditionals/if.js
@@ -1,16 +1,12 @@
 'use strict';
-// overwrite default handlebars 'if' helper
-// this adds support for an inline helper, {{if foo bar}}
-// (if foo is truthy, print bar)
-// as well as an inline if/else helper, {{if foo bar else=baz}}
-// (if foo is truthy, print bar. otherwise, print baz)
-
 /**
- * if
+ * overwrite default handlebars 'if' helper
+ * this adds support for an inline helper, `{{if foo bar}}` _(if foo is truthy, print bar)_
+ * as well as an inline if/else helper, `{{if foo bar else=baz}}` _(if foo is truthy, print bar. otherwise, print baz)_
  * @param  {*} conditional to check for truthiness
  * @param  {*} value       to print if conditional is truthy
  * @param  {object} [options]
- * @return {string}
+ * @return {string} if inline, otherwise calls block functions
  */
 module.exports = function (conditional, value, options) {
   if (options === undefined) {
@@ -26,4 +22,9 @@ module.exports = function (conditional, value, options) {
       return options.hash.else || ''; // return falsy value or emptystring
     }
   }
+};
+
+module.exports.example = {
+  code: '{{ if true "bar" else="baz" }}',
+  result: '"bar"'
 };

--- a/helpers/conditionals/ifAll.js
+++ b/helpers/conditionals/ifAll.js
@@ -3,8 +3,7 @@ const _ = require('lodash');
 
 /**
  * block helper for checking if ALL arguments passed in are truthy
- * e.g. {{#ifAll foo bar baz}}all are truthy{{else}}not all are truthy{{/ifAll}}
- * @return {string}
+ * @return {string} calls block functions
  */
 module.exports = function () {
   const conditionals = _.initial(arguments),
@@ -19,4 +18,12 @@ module.exports = function () {
   } else {
     return options.inverse(this);
   }
+};
+
+module.exports.example = {
+  code: `{{#ifAll foo bar baz}}
+  all are truthy
+{{else}}
+  not all are truthy
+{{/ifAll}}`
 };

--- a/helpers/conditionals/ifAny.js
+++ b/helpers/conditionals/ifAny.js
@@ -3,8 +3,7 @@ const _ = require('lodash');
 
 /**
  * block helper for checking if ANY arguments passed in are truthy
- * e.g. {{#ifAny foo bar baz}}at least one is truthy{{else}}none are truthy{{/ifAny}}
- * @return {string}
+ * @return {string} calls block functions
  */
 module.exports = function () {
   const conditionals = _.initial(arguments),
@@ -21,4 +20,12 @@ module.exports = function () {
   } else {
     return options.inverse(this);
   }
+};
+
+module.exports.example = {
+  code: `{{#ifAny foo bar baz}}
+  at least one is truthy
+{{else}}
+  none are truthy
+{{/ifAny}}`
 };

--- a/helpers/conditionals/ifNone.js
+++ b/helpers/conditionals/ifNone.js
@@ -3,8 +3,7 @@ const _ = require('lodash');
 
 /**
  * block helper for checking if NO arguments passed in are truthy
- * e.g. {{#ifNone foo bar baz}}all are falsy{{else}}not all are falsy{{/ifNone}}
- * @return {string}
+ * @return {string} calls block functions
  */
 module.exports = function () {
   const conditionals = _.initial(arguments),
@@ -22,4 +21,12 @@ module.exports = function () {
   } else {
     return options.fn(this);
   }
+};
+
+module.exports.example = {
+  code: `{{#ifNone foo bar baz}}
+  all are falsy
+{{else}}
+  not all are falsy
+{{/ifNone}}`
 };

--- a/helpers/conditionals/modulo.js
+++ b/helpers/conditionals/modulo.js
@@ -1,4 +1,12 @@
 'use strict';
+/**
+ * compare the modulo of two values to a third value
+ * @param  {number} dividend
+ * @param  {number} divisor
+ * @param  {number} remainder
+ * @param  {object} [options]
+ * @return {string} if inline, otherwise calls block functions
+ */
 module.exports = function (dividend, divisor, remainder, options) {
   var result = dividend % divisor;
 
@@ -9,4 +17,9 @@ module.exports = function (dividend, divisor, remainder, options) {
   } else {
     return options.inverse ? options.inverse(this) : '';
   }
+};
+
+module.exports.example = {
+  code: '{{modulo 3 2 1}}',
+  result: 'true'
 };

--- a/helpers/html/striptags.js
+++ b/helpers/html/striptags.js
@@ -1,3 +1,10 @@
 'use strict';
-// passthrough to striptags
+/**
+ * straight passthrough to striptags
+ */
 module.exports = require('striptags');
+
+module.exports.example = {
+  code: '{{ striptags "<p><b>Hello</b> <em>World!</em></p>" }}',
+  result: 'Hello World!'
+};

--- a/helpers/html/wordCount.js
+++ b/helpers/html/wordCount.js
@@ -4,10 +4,15 @@ const stripTags = require('striptags');
 /**
  * counts the words in a string of text or html
  * @param {string} [html]
- * @returns {string}
+ * @returns {number} the number of words
  */
 function htmlToWordCount(html) {
-  return stripTags(html || '').split(' ').filter(word => word.trim()).length.toString();
+  return stripTags(html || '').split(' ').filter(word => word.trim()).length;
 }
 
 module.exports = htmlToWordCount;
+
+module.exports.example = {
+  code: '{{wordCount "<div> This is <b> cool </b> </div>"}}',
+  result: '3'
+};

--- a/helpers/misc/indexOf.js
+++ b/helpers/misc/indexOf.js
@@ -1,8 +1,19 @@
 'use strict';
+/**
+ * get the index of something inside something else
+ * @param  {*} outside array, string, etc (anything with `indexOf`)
+ * @param  {*} inside  anything that can exist inside something else
+ * @return {number}
+ */
 module.exports = function (outside, inside) {
   if (!outside) {
     throw new Error('indexOf helper needs something to look inside!');
   } else {
     return outside.indexOf(inside);
   }
+};
+
+module.exports.example = {
+  code: '{{ indexOf "foo" "o" }}',
+  result: '1'
 };

--- a/helpers/misc/set.js
+++ b/helpers/misc/set.js
@@ -3,12 +3,15 @@ const _ = require('lodash');
 
 /**
  * set data into current context
- * @param  {string} key _.set() key/path
- * @param  {*} val
- * @return {string} doesn't actually print anything
+ * _note:_ doesn't return anything
+ * @param  {string} key `_.set()` key/path
+ * @param  {*} val value to set
  */
 module.exports = function (key, val) {
   _.set(this, key, val);
+};
 
-  return '';
+module.exports.example = {
+  code: '{{ set "a.b.c" "abc" }}{{ a.b.c }}',
+  result: '"abc"'
 };

--- a/helpers/numbers/addCommas.js
+++ b/helpers/numbers/addCommas.js
@@ -3,11 +3,9 @@ const comma = require('comma-it');
 
 /**
  * add commas to numbers.
- * note: this overrides handlebars-helpers' addCommas helper
- * because we want to preserve zeroes in decimals (for money)
- * e.g. 1234.50 → 1,234.50 instead of 1,234.5
- * note: decimals are only preserved if passed in as a string
- * (they don't exist in js numbers)
+ * _note:_ this overrides handlebars-helpers' `addCommas` helper because we want to preserve zeroes in decimals (for money)
+ * e.g. `1234.50` → `1,234.50` instead of `1,234.5`
+ * _note:_ decimals are only preserved if passed in as a string (they don't exist in js numbers)
  * @param  {number|string} num
  * @return {string}
  */
@@ -19,5 +17,9 @@ module.exports = function (num) {
   // otherwise set the precision to zero (for intergers)
 
   return comma(str, { precision: precision, thousandSeperator: ',', decimalSeperator: '.' });
+};
 
+module.exports.example = {
+  code: '{{ addCommas "1234.50" }}',
+  result: '"1,234.50"'
 };

--- a/helpers/numbers/addCommas.test.js
+++ b/helpers/numbers/addCommas.test.js
@@ -29,6 +29,7 @@ describe(name, function () {
   });
 
   it('should add commas to decimals (hundreds place)', function () {
+    expect(tpl({a: '1234.50'})).to.equal('1,234.50');
     expect(tpl({a: 1234.56})).to.equal('1,234.56');
   });
 });

--- a/helpers/numbers/toK.js
+++ b/helpers/numbers/toK.js
@@ -1,8 +1,8 @@
 'use strict';
 /**
- * convert number to shorthand
- * e.g. 1000 → 1k
- * @param  {number|string} x
+ * format thousands using `k`
+ * e.g. `1000` → `1k`
+ * @param  {number|string} x number to format
  * @return {string}
  */
 module.exports = function (x) {
@@ -22,4 +22,9 @@ module.exports = function (x) {
     // number is less than 1000, so no conversion necessary
     return x;
   }
+};
+
+module.exports.example = {
+  code: '{{ toK 1234.5 }}',
+  result: '"1.2k"'
 };

--- a/helpers/objects/commaSeparated.js
+++ b/helpers/objects/commaSeparated.js
@@ -2,9 +2,7 @@
 const _ = require('lodash');
 
 /**
- * Turn an object into a comma-delineated list of key names,
- * based on if their values are true/false
- * e.g. { a: true, b: false, c: true } → a, b, c
+ * Turn an object into a comma-delineated list of key names, depending if their values are true/false
  * @param  {object} obj
  * @param  {boolean} shouldCapitalize capitalizes first word in each key
  * @return {string}
@@ -26,4 +24,9 @@ module.exports = function (obj, shouldCapitalize) {
 
     return result;
   }, '');
+};
+
+module.exports.example = {
+  code: '{{ commaSeparated {alpha: true, "bravo charlie": true} true }}',
+  result: '"Alpha, Bravo charlie"'
 };

--- a/helpers/strings/kebabCase.js
+++ b/helpers/strings/kebabCase.js
@@ -1,4 +1,12 @@
 'use strict';
 const _ = require('lodash');
 
-module.exports = _.kebabCase; // straight passthrough
+/**
+ * straight passthrough to `_.kebabCase`
+ */
+module.exports = _.kebabCase;
+
+module.exports.example = {
+  code: '{{ kebabCase "Foo Bar Baz" }}',
+  result: '"foo-bar-baz"'
+};

--- a/helpers/strings/longestWord.js
+++ b/helpers/strings/longestWord.js
@@ -2,10 +2,9 @@
 const _ = require('lodash');
 
 /**
- * returns the number of characters in the longest word of
- * a string. Punctuation is NOT ignored.
- * @param  {string} str
- * @return {number}
+ * returns the number of characters in the longest word of a string. Punctuation is NOT ignored.
+ * @param  {string} str string to search through
+ * @return {number} of letters in the longest word
  */
 module.exports = function (str) {
   if (!_.isString(str)) {
@@ -19,4 +18,9 @@ module.exports = function (str) {
       return prev;
     }
   }, '').length;
+};
+
+module.exports.example = {
+  code: '{{ longestWord "Foo Ba b" }}',
+  result: '3'
 };

--- a/helpers/strings/randomString.js
+++ b/helpers/strings/randomString.js
@@ -3,11 +3,11 @@ const randomstring = require('randomstring'),
   _ = require('lodash');
 
 /**
- * generatea random string
- * e.g. `greatest-hit-` → `greatest-hit-noctz56h`
- * note: allows passing length=x to generate strings of different lengths
- * @param  {string} [prefix]
+ * generate a random string
+ * _note:_ by default it generates an 8-character string
+ * @param  {string} [prefix] string to append random stuff to
  * @param {object} [options]
+ * @param {number} [options.hash.characters] generate string of a custom length
  * @return {string}
  */
 module.exports = function (prefix, options) {
@@ -21,4 +21,9 @@ module.exports = function (prefix, options) {
 
   // default to 8 chars, but allow passing in any length
   return prefix + randomstring.generate(options.hash.characters || 8);
+};
+
+module.exports.example = {
+  code: '{{ randomString "greatest-hit-" characters=3 }}',
+  result: '"greatest-hit-z56"'
 };

--- a/helpers/time/articleDate.js
+++ b/helpers/time/articleDate.js
@@ -8,8 +8,8 @@ function ampm(date) {
 }
 
 /**
- * generate article dates and times
- * @param  {Date} datetime
+ * generate article dates and times, based on a relative format
+ * @param  {Date|string} datetime for `moment.js` to parse
  * @return {string}
  */
 module.exports = function (datetime) {
@@ -39,4 +39,9 @@ module.exports = function (datetime) {
   } else {
     return '';
   }
+};
+
+module.exports.example = {
+  code: '{{ articleDate "Fri, 13 Jan 2017 18:22:16 GMT" }}',
+  result: '"Yesterday at 6:22 p.m."'
 };

--- a/helpers/urls/urlencode.js
+++ b/helpers/urls/urlencode.js
@@ -1,8 +1,12 @@
 'use strict';
 const _ = require('lodash');
 
-// ported from the nunjucks urlencode filter
-// note: handlebars-helpers' `encodeURI` doesn't handle arrays or objects
+/**
+ * encode urls (ported from the nunjucks `urlencode` filter)
+ * _note:_ `handlebars-helpers` contains an `encodeURI` helper, but it doesn't handle arrays or objects.
+ * @param  {*} obj data to encode
+ * @return {string} urlencoded data
+ */
 module.exports = function (obj) {
   if (_.isString(obj)) {
     return encodeURIComponent(obj);
@@ -23,4 +27,9 @@ module.exports = function (obj) {
 
     return parts.join('&');
   }
+};
+
+module.exports.example = {
+  code: '{{ urlencode "&" }}',
+  result: '"%26"'
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "chai": "^3.5.0",
     "chalk": "^1.1.3",
     "coveralls": "^2.11.15",
+    "documentation": "^4.0.0-beta.18",
     "eslint": "^3.13.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nymag-handlebars",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A collection of helpers and partials for handlebars",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "lint": "eslint helpers partials test index.js",
     "test-local": "npm run lint && istanbul cover _mocha",
-    "test": "npm run lint && istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
+    "test": "npm run lint && istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
+    "generate-readme": "node docs/generate-readme.js"
   },
   "repository": {
     "type": "git",
@@ -26,6 +27,7 @@
   "homepage": "https://github.com/nymag/nymag-handlebars#readme",
   "devDependencies": {
     "chai": "^3.5.0",
+    "chalk": "^1.1.3",
     "coveralls": "^2.11.15",
     "eslint": "^3.13.0",
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "lint": "eslint helpers partials test index.js",
     "test-local": "npm run lint && istanbul cover _mocha",
     "test": "npm run lint && istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
-    "generate-readme": "node docs/generate-readme.js"
+    "generate-readme": "node docs/generate-readme.js && git add README.md"
   },
+  "pre-commit": [
+    "generate-readme"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nymag/nymag-handlebars.git"
@@ -32,7 +35,8 @@
     "documentation": "^4.0.0-beta.18",
     "eslint": "^3.13.0",
     "istanbul": "^0.4.5",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "pre-commit": "^1.2.2"
   },
   "dependencies": {
     "comma-it": "0.0.7",


### PR DESCRIPTION
* fix #8 
* generate readme via handlebars (!!!)
* auto-generate on precommit hook
* table of contents for all helpers
* details for categories, helpers, and partials
* added contributing section

Helpers have this info now:

* link to code and tests (if they exist)
* description pulled from JSDocs
* params pulled from JSDocs
* returned value pulled from JSDocs
* code example (and result) exported in `module.exports.example`

[**Take a look!**](https://github.com/nymag/nymag-handlebars/blob/bea60ee45a9d6a2de1b3bd3401f1a3c2bd62b36e/README.md) (note, toc and such links won't work until it's merged into master)