### PR TITLE
add default helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ app.set('view engine', 'handlebars');
 
 # Helpers
 
-Currently **24 helpers** in **9 categories**:
+Currently **25 helpers** in **9 categories**:
 
 
 ### components
@@ -68,6 +68,7 @@ Currently **24 helpers** in **9 categories**:
 
 ### misc
 
+* [**default**](https://github.com/nymag/nymag-handlebars#default--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/default.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/default.test.js) )
 * [**indexOf**](https://github.com/nymag/nymag-handlebars#indexof--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/indexOf.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/indexOf.test.js) )
 * [**set**](https://github.com/nymag/nymag-handlebars#set--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/set.test.js) )
 
@@ -318,6 +319,21 @@ counts the words in a string of text or html
 
 ## misc
 
+
+### default ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/default.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/default.test.js) )
+
+return the first value if it's not empty, otherwise return the second value<br /> _note:_  this overrides handlebar-helper's  [default](https://github.com/helpers/handlebars-helpers#default)  helper, since that only checks for null values (not all falsy/empty values)
+
+#### Params
+* `value` _(*)_ to check
+* `defaultValue` _(*)_ value to return if first value is falsy
+
+#### Example
+
+```hbs
+{{ default "" "foo" }}
+//=> foo
+```
 
 ### indexOf ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/indexOf.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/misc/indexOf.test.js) )
 

--- a/helpers/misc/default.js
+++ b/helpers/misc/default.js
@@ -1,0 +1,22 @@
+'use strict';
+const _ = require('lodash');
+
+/**
+ * return the first value if it's not empty, otherwise return the second value
+ * _note:_ this overrides handlebar-helper's [default](https://github.com/helpers/handlebars-helpers#default) helper, since that only checks for null values (not all falsy/empty values)
+ * @param  {*} value to check
+ * @param  {*} defaultValue  value to return if first value is falsy
+ * @return {*}
+ */
+module.exports = function (value, defaultValue) {
+  if (_.isObject(value) || _.isArray(value)) {
+    return !_.isEmpty(value) ? value : defaultValue;
+  } else {
+    return !!value ? value : defaultValue;
+  }
+};
+
+module.exports.example = {
+  code: '{{ default "" "foo" }}',
+  result: 'foo'
+};

--- a/helpers/misc/default.test.js
+++ b/helpers/misc/default.test.js
@@ -1,0 +1,28 @@
+'use strict';
+const name = getName(__filename),
+  tpl = hbs.compile('{{ default a b }}');
+
+describe(name, function () {
+  it('returns the first value if non-empty', function () {
+    expect(tpl({a: 'yes', b: 'no'})).to.equal('yes');
+    expect(tpl({a: [''], b: 'no'})).to.equal(''); // array has items
+    expect(tpl({a: { foo: '' }, b: 'no'})).to.equal('[object Object]'); // object has property
+    expect(tpl({a: 1, b: 'no'})).to.equal('1');
+    expect(tpl({a: true, b: 'no'})).to.equal('true');
+  });
+
+  it('returns the second value if empty', function () {
+    expect(tpl({a: '', b: 'no'})).to.equal('no');
+    expect(tpl({a: [], b: 'no'})).to.equal('no');
+    expect(tpl({a: {}, b: 'no'})).to.equal('no');
+    expect(tpl({a: 0, b: 'no'})).to.equal('no');
+    expect(tpl({a: false, b: 'no'})).to.equal('no');
+  });
+
+  // test below is a regression test from handlebars-helpers
+  it('should fallback to the default value when no value exists', function () {
+    expect(tpl({a: null, b: 'no'})).to.equal('no');
+    expect(tpl({a: undefined, b: 'no'})).to.equal('no');
+    expect(tpl({b: 'no'})).to.equal('no');
+  });
+});


### PR DESCRIPTION
this overrides the `default` helper from handlebars-helpers to better reflect how we use default values (emptystrings are falsy, yo)

fixes #9