### PR TITLE
client-side support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# compiled client-side distribution
+dist/

--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ app.set('view engine', 'handlebars');
 
 # Helpers
 
-Currently **30 helpers** in **10 categories**:
+Currently **31 helpers** in **10 categories**:
 
 
 ### arrays
 
+* [**join**](https://github.com/nymag/nymag-handlebars#join--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/join.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/join.test.js) )
 * [**range**](https://github.com/nymag/nymag-handlebars#range--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/range.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/range.test.js) )
 
 ### components
@@ -110,6 +111,23 @@ Currently **30 helpers** in **10 categories**:
 
 ## arrays
 
+
+### join ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/join.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/join.test.js) )
+
+join all elements of array into a string, optionally using a given separator
+
+#### Params
+* `array` _(array)_ 
+* `[sep]` _(string)_ the separator to use (defaults to ', ')
+
+**Returns** _(string)_ 
+
+#### Example
+
+```hbs
+{{ join ["a", "b", "c"] "-" }}
+//=> "a-b-c"
+```
 
 ### range ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/range.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/range.test.js) )
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ app.set('view engine', 'handlebars');
 
 # Helpers
 
-Currently **32 helpers** in **10 categories**:
+Currently **33 helpers** in **10 categories**:
 
 
 ### arrays
@@ -98,6 +98,7 @@ Currently **32 helpers** in **10 categories**:
 * [**lowercase**](https://github.com/nymag/nymag-handlebars#lowercase--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/lowercase.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/lowercase.test.js) )
 * [**randomString**](https://github.com/nymag/nymag-handlebars#randomstring--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.test.js) )
 * [**replace**](https://github.com/nymag/nymag-handlebars#replace--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/replace.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/replace.test.js) )
+* [**trim**](https://github.com/nymag/nymag-handlebars#trim--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/trim.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/trim.test.js) )
 
 ### time
 
@@ -633,6 +634,22 @@ replace all occurrences of  `a`  with  `b` <br /> _note:_  this does simple stri
 ```hbs
 {{ replace "Foo Bar" "Bar" "Baz" }}
 //=> "Foo Baz"
+```
+
+### trim ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/trim.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/trim.test.js) )
+
+trim leading and trailing whitespace from a string
+
+#### Params
+* `str` _(string)_ 
+
+**Returns** _(string)_ 
+
+#### Example
+
+```hbs
+{{ trim "   Foo   " }}
+//=> "Foo"
 ```
 
 ## time

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ app.set('view engine', 'handlebars');
 
 # Helpers
 
-Currently **29 helpers** in **10 categories**:
+Currently **30 helpers** in **10 categories**:
 
 
 ### arrays
@@ -95,6 +95,7 @@ Currently **29 helpers** in **10 categories**:
 * [**longestWord**](https://github.com/nymag/nymag-handlebars#longestword--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.test.js) )
 * [**lowercase**](https://github.com/nymag/nymag-handlebars#lowercase--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/lowercase.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/lowercase.test.js) )
 * [**randomString**](https://github.com/nymag/nymag-handlebars#randomstring--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.test.js) )
+* [**replace**](https://github.com/nymag/nymag-handlebars#replace--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/replace.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/replace.test.js) )
 
 ### time
 
@@ -504,9 +505,18 @@ get property in object<br />this is similar to handlebars-helpers'  [`get`](http
 
 ### concat ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/concat.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/concat.test.js) )
 
-_No description_
+concatenate any number of strings
 
 
+
+**Returns** _(string)_ concatenated string
+
+#### Example
+
+```hbs
+{{ concat "Foo" "Bar" "Baz" }}
+//=> "FooBarBaz"
+```
 
 ### kebabCase ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/kebabCase.js) | no tests )
 
@@ -569,6 +579,24 @@ generate a random string<br /> _note:_  by default it generates an 8-character s
 ```hbs
 {{ randomString "greatest-hit-" characters=3 }}
 //=> "greatest-hit-z56"
+```
+
+### replace ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/replace.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/replace.test.js) )
+
+replace all occurrences of  `a`  with  `b` <br /> _note:_  this does simple string replacement, not regex
+
+#### Params
+* `str` _(string)_ to replace inside
+* `a` _(string)_ to replace
+* `b` _(string)_ the replacement
+
+**Returns** _(string)_ 
+
+#### Example
+
+```hbs
+{{ replace "Foo Bar" "Bar" "Baz" }}
+//=> "Foo Baz"
 ```
 
 ## time

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ app.set('view engine', 'handlebars');
 
 # Helpers
 
-Currently **33 helpers** in **10 categories**:
+Currently **34 helpers** in **10 categories**:
 
 
 ### arrays
@@ -80,6 +80,7 @@ Currently **33 helpers** in **10 categories**:
 
 ### numbers
 
+* [**add**](https://github.com/nymag/nymag-handlebars#add--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/add.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/add.test.js) )
 * [**addCommas**](https://github.com/nymag/nymag-handlebars#addcommas--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.test.js) )
 * [**num**](https://github.com/nymag/nymag-handlebars#num--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/num.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/num.test.js) )
 * [**subtract**](https://github.com/nymag/nymag-handlebars#subtract--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/subtract.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/subtract.test.js) )
@@ -435,6 +436,23 @@ set data into current context<br /> _note:_  doesn't return anything
 
 ## numbers
 
+
+### add ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/add.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/add.test.js) )
+
+Return the product of  `a`  plus  `b`
+
+#### Params
+* `a` _(number)_ 
+* `b` _(number)_ 
+
+**Returns** _(number)_ 
+
+#### Example
+
+```hbs
+{{ add 3 2 }}
+//=> 5
+```
 
 ### addCommas ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.test.js) )
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ app.set('view engine', 'handlebars');
 
 # Helpers
 
-Currently **34 helpers** in **10 categories**:
+Currently **36 helpers** in **10 categories**:
 
 
 ### arrays
@@ -93,6 +93,8 @@ Currently **34 helpers** in **10 categories**:
 
 ### strings
 
+* [**capitalize**](https://github.com/nymag/nymag-handlebars#capitalize--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/capitalize.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/capitalize.test.js) )
+* [**capitalizeAll**](https://github.com/nymag/nymag-handlebars#capitalizeall--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/capitalizeAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/capitalizeAll.test.js) )
 * [**concat**](https://github.com/nymag/nymag-handlebars#concat--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/concat.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/concat.test.js) )
 * [**kebabCase**](https://github.com/nymag/nymag-handlebars#kebabcase--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/kebabCase.js) | no tests )
 * [**longestWord**](https://github.com/nymag/nymag-handlebars#longestword--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.test.js) )
@@ -557,6 +559,38 @@ get property in object<br />this is similar to handlebars-helpers'  [`get`](http
 
 ## strings
 
+
+### capitalize ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/capitalize.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/capitalize.test.js) )
+
+capitalize the first character in a string
+
+#### Params
+* `str` _(string)_ 
+
+**Returns** _(string)_ 
+
+#### Example
+
+```hbs
+{{ capitalize "foo bar" }}
+//=> "Foo bar"
+```
+
+### capitalizeAll ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/capitalizeAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/capitalizeAll.test.js) )
+
+capitalize every word in a string
+
+#### Params
+* `str` _(string)_ 
+
+**Returns** _(string)_ 
+
+#### Example
+
+```hbs
+{{ capitalizeAll "foo bar" }}
+//=> "Foo Bar"
+```
 
 ### concat ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/concat.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/concat.test.js) )
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ app.set('view engine', 'handlebars');
 
 # Helpers
 
-Currently **27 helpers** in **10 categories**:
+Currently **28 helpers** in **10 categories**:
 
 
 ### arrays
@@ -92,6 +92,7 @@ Currently **27 helpers** in **10 categories**:
 * [**concat**](https://github.com/nymag/nymag-handlebars#concat--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/concat.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/concat.test.js) )
 * [**kebabCase**](https://github.com/nymag/nymag-handlebars#kebabcase--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/kebabCase.js) | no tests )
 * [**longestWord**](https://github.com/nymag/nymag-handlebars#longestword--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/longestWord.test.js) )
+* [**lowercase**](https://github.com/nymag/nymag-handlebars#lowercase--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/lowercase.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/lowercase.test.js) )
 * [**randomString**](https://github.com/nymag/nymag-handlebars#randomstring--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.test.js) )
 
 ### time
@@ -517,6 +518,15 @@ returns the number of characters in the longest word of a string. Punctuation is
 {{ longestWord "Foo Ba b" }}
 //=> 3
 ```
+
+### lowercase ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/lowercase.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/lowercase.test.js) )
+
+lower cases a string<br /> _note:_  non-strings will return emptystring
+
+#### Params
+* `str` _(string)_ 
+
+**Returns** _(string)_ lower cased
 
 ### randomString ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.test.js) )
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ app.set('view engine', 'handlebars');
 
 # Helpers
 
-Currently **28 helpers** in **10 categories**:
+Currently **29 helpers** in **10 categories**:
 
 
 ### arrays
@@ -80,6 +80,7 @@ Currently **28 helpers** in **10 categories**:
 
 * [**addCommas**](https://github.com/nymag/nymag-handlebars#addcommas--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.test.js) )
 * [**num**](https://github.com/nymag/nymag-handlebars#num--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/num.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/num.test.js) )
+* [**subtract**](https://github.com/nymag/nymag-handlebars#subtract--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/subtract.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/subtract.test.js) )
 * [**toK**](https://github.com/nymag/nymag-handlebars#tok--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.test.js) )
 
 ### objects
@@ -429,6 +430,23 @@ converts things (usually strings) into numbers<br /> _note:_  this is useful if 
 //=> 123
 ```
 
+### subtract ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/subtract.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/subtract.test.js) )
+
+Return the product of  `a`  minus  `b`
+
+#### Params
+* `a` _(number)_ 
+* `b` _(number)_ 
+
+**Returns** _(number)_ 
+
+#### Example
+
+```hbs
+{{ subtract 3 2 }}
+//=> 1
+```
+
 ### toK ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/toK.test.js) )
 
 format thousands using  `k` <br />e.g.  `1000`  →  `1k`
@@ -527,6 +545,13 @@ lower cases a string<br /> _note:_  non-strings will return emptystring
 * `str` _(string)_ 
 
 **Returns** _(string)_ lower cased
+
+#### Example
+
+```hbs
+{{ lowercase "Foo" }}
+//=> "foo"
+```
 
 ### randomString ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/randomString.test.js) )
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@ app.set('view engine', 'handlebars');
 
 # Helpers
 
-Currently **31 helpers** in **10 categories**:
+Currently **32 helpers** in **10 categories**:
 
 
 ### arrays
 
 * [**join**](https://github.com/nymag/nymag-handlebars#join--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/join.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/join.test.js) )
+* [**map**](https://github.com/nymag/nymag-handlebars#map--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/map.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/map.test.js) )
 * [**range**](https://github.com/nymag/nymag-handlebars#range--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/range.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/range.test.js) )
 
 ### components
@@ -127,6 +128,23 @@ join all elements of array into a string, optionally using a given separator
 ```hbs
 {{ join ["a", "b", "c"] "-" }}
 //=> "a-b-c"
+```
+
+### map ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/map.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/map.test.js) )
+
+map through array, call function on each item
+
+#### Params
+* `array` _(array|string)_ of items to iterate through
+* `fn` _(function)_ to run on each item
+
+**Returns** _(array)_ 
+
+#### Example
+
+```hbs
+{{ join (map [{ a: "1" }, { a: "2" }] (getProp "a")) }}
+//=> "1, 2"
 ```
 
 ### range ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/range.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/arrays/range.test.js) )
@@ -515,7 +533,7 @@ get property in object<br />this is similar to handlebars-helpers'  [`get`](http
 
 ```hbs
 {{ join (map [{ a: "1" }, { a: "2" }] (getProp "a"))}}
-//=> "1,2"
+//=> "1, 2"
 ```
 
 ## strings

--- a/client.js
+++ b/client.js
@@ -1,7 +1,6 @@
 'use strict';
 const helpersReq = require.context('./helpers', true, /^.*?\/[\w\-]+\.js$/),
   partialsReq = require.context('./partials', false, /^.*\.hbs$/),
-  yaml = require('helper-yaml'),
   path = require('path');
 
 module.exports = function (env) {
@@ -10,8 +9,12 @@ module.exports = function (env) {
   }
 
   // add 3rd party helpers first (in case we need to overwrite any)
-  // todo: add handlebars-helpers when it works client-side
-  env.registerHelper('yaml', yaml.sync);
+  require('./third-party-helpers')(env);
+
+  // add noop to `read` helper on the client-side
+  // todo: deprecate this when we figure out how to precompile these assets
+  // (and thus remove the helper from the server-side)
+  env.registerHelper('read', () => '');
 
   // add helpers
   helpersReq.keys().forEach(h => env.registerHelper(path.basename(h, '.js'), helpersReq(h)));

--- a/client.js
+++ b/client.js
@@ -1,0 +1,23 @@
+'use strict';
+const helpersReq = require.context('./helpers', true, /^.*?\/[\w\-]+\.js$/),
+  partialsReq = require.context('./partials', false, /^.*\.hbs$/),
+  yaml = require('helper-yaml'),
+  path = require('path');
+
+module.exports = function (env) {
+  if (!env) {
+    env = require('handlebars/dist/handlebars.runtime.min.js');
+  }
+
+  // add 3rd party helpers first (in case we need to overwrite any)
+  // todo: add handlebars-helpers when it works client-side
+  env.registerHelper('yaml', yaml.sync);
+
+  // add helpers
+  helpersReq.keys().forEach(h => env.registerHelper(path.basename(h, '.js'), helpersReq(h)));
+
+  // add partials
+  partialsReq.keys().forEach(p => env.registerPartial(path.basename(p, '.hbs'), partialsReq(p)));
+
+  return env;
+};

--- a/helpers/arrays/join.js
+++ b/helpers/arrays/join.js
@@ -1,0 +1,22 @@
+'use strict';
+const _ = require('lodash');
+
+/**
+ * join all elements of array into a string, optionally using a given separator
+ * @param {array} array
+ * @param {string} [sep] the separator to use (defaults to ', ')
+ * @return {string}
+ */
+module.exports = function (array, sep) {
+  if (!_.isArray(array)) {
+    return '';
+  }
+
+  sep = typeof sep !== 'string' ? ', ' : sep;
+  return array.join(sep);
+};
+
+module.exports.example = {
+  code: '{{ join ["a", "b", "c"] "-" }}',
+  result: '"a-b-c"'
+};

--- a/helpers/arrays/join.test.js
+++ b/helpers/arrays/join.test.js
@@ -1,0 +1,19 @@
+'use strict';
+const name = getName(__filename),
+  tpl = hbs.compile('{{ join a b }}');
+
+describe(name, function () {
+  it('returns emptystring if undefined', function () {
+    expect(tpl()).to.equal('');
+    expect(tpl({})).to.equal('');
+    expect(tpl({a: []})).to.equal('');
+  });
+
+  it('should join items by the default separator', function () {
+    expect(tpl({a: ['a', 'b', 'c']})).to.equal('a, b, c');
+  });
+
+  it('should join by a custom separator', function () {
+    expect(tpl({a: ['a', 'b', 'c'], b: ' | '})).to.equal('a | b | c');
+  });
+});

--- a/helpers/arrays/map.js
+++ b/helpers/arrays/map.js
@@ -1,0 +1,23 @@
+'use strict';
+const _ = require('lodash');
+
+/**
+ * map through array, call function on each item
+ * @param {array|string} array of items to iterate through
+ * @param {function} fn to run on each item
+ * @return {array}
+ */
+module.exports = function (array, fn) {
+  if (_.isArray(array)) {
+    return _.map(array, fn);
+  } else if (_.isString(array)) {
+    return _.map(array.split(''), fn);
+  } else {
+    return [];
+  }
+};
+
+module.exports.example = {
+  code: '{{ join (map [{ a: "1" }, { a: "2" }] (getProp "a")) }}',
+  result: '"1, 2"'
+};

--- a/helpers/arrays/map.test.js
+++ b/helpers/arrays/map.test.js
@@ -1,0 +1,19 @@
+'use strict';
+const name = getName(__filename),
+  tpl = hbs.compile('{{ join (map a (getProp "a")) }}');
+
+describe(name, function () {
+  it('returns empty array if undefined', function () {
+    expect(tpl()).to.equal('');
+    expect(tpl({})).to.equal('');
+    expect(tpl({a: []})).to.equal('');
+  });
+
+  it('should map the items in the array and return new values', function () {
+    expect(tpl({a: [{ a: '1' }, { a: '2' }]})).to.equal('1, 2');
+  });
+
+  it('should work with a string value', function () {
+    expect(hbs.compile('{{ join (map a double) " " }}')({a: 'abc', double: (a) => a + a})).to.equal('aa bb cc');
+  });
+});

--- a/helpers/numbers/add.js
+++ b/helpers/numbers/add.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * Return the product of `a` plus `b`
+ * @param  {number} a
+ * @param {number} b
+ * @return {number}
+ */
+module.exports = function (a, b) {
+  return parseInt(a, 10) + parseInt(b, 10);
+};
+
+module.exports.example = {
+  code: '{{ add 3 2 }}',
+  result: '5'
+};

--- a/helpers/numbers/add.test.js
+++ b/helpers/numbers/add.test.js
@@ -1,0 +1,18 @@
+'use strict';
+const name = getName(__filename),
+  tpl = hbs.compile('{{ add a b }}');
+
+describe(name, function () {
+  it('returns NaN if args are undefined', function () {
+    expect(tpl()).to.equal('NaN');
+  });
+
+  it('returns NaN if arguments are not numbers', function () {
+    expect(tpl({a: '1', b: 'ok'})).to.equal('NaN');
+    expect(tpl({a: 'bad', b: '123'})).to.equal('NaN');
+  });
+
+  it('returns the sum of two numbers', function () {
+    expect(tpl({a: 5, b: 3})).to.equal('8');
+  });
+});

--- a/helpers/numbers/subtract.js
+++ b/helpers/numbers/subtract.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * Return the product of `a` minus `b`
+ * @param  {number} a
+ * @param {number} b
+ * @return {number}
+ */
+module.exports = function (a, b) {
+  return a - b;
+};
+
+module.exports.example = {
+  code: '{{ subtract 3 2 }}',
+  result: '1'
+};

--- a/helpers/numbers/subtract.test.js
+++ b/helpers/numbers/subtract.test.js
@@ -1,0 +1,13 @@
+'use strict';
+const name = getName(__filename),
+  tpl = hbs.compile('{{ subtract a b }}');
+
+describe(name, function () {
+  it('returns NaN if something fails', function () {
+    expect(tpl()).to.equal('NaN');
+  });
+
+  it('returns the difference of two numbers', function () {
+    expect(tpl({a: 5, b: 3})).to.equal('2');
+  });
+});

--- a/helpers/objects/getProp.js
+++ b/helpers/objects/getProp.js
@@ -14,5 +14,5 @@ module.exports = function (prop) {
 
 module.exports.example = {
   code: '{{ join (map [{ a: "1" }, { a: "2" }] (getProp "a"))}}',
-  result: '"1,2"'
+  result: '"1, 2"'
 };

--- a/helpers/strings/capitalize.js
+++ b/helpers/strings/capitalize.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/**
+ * capitalize the first character in a string
+ * @param {string} str
+ * @return {string}
+ */
+module.exports = function (str) {
+  if (str && typeof str === 'string') {
+    return str.charAt(0).toUpperCase()
+      + str.slice(1);
+  }
+};
+
+module.exports.example = {
+  code: '{{ capitalize "foo bar" }}',
+  result: '"Foo bar"'
+};

--- a/helpers/strings/capitalize.test.js
+++ b/helpers/strings/capitalize.test.js
@@ -1,0 +1,13 @@
+'use strict';
+const name = getName(__filename),
+  tpl = hbs.compile('{{ capitalize a }}');
+
+describe(name, function () {
+  it('returns emptystring if undefined', function () {
+    expect(tpl()).to.equal('');
+  });
+
+  it('capitalizes first character in a string', function () {
+    expect(tpl({a: 'foo bar'})).to.equal('Foo bar');
+  });
+});

--- a/helpers/strings/capitalizeAll.js
+++ b/helpers/strings/capitalizeAll.js
@@ -1,0 +1,20 @@
+'use strict';
+const capitalize = require('./capitalize');
+
+/**
+ * capitalize every word in a string
+ * @param {string} str
+ * @return {string}
+ */
+module.exports = function (str) {
+  if (str && typeof str === 'string') {
+    return str.replace(/\w\S*/g, function (word) {
+      return capitalize(word);
+    });
+  }
+};
+
+module.exports.example = {
+  code: '{{ capitalizeAll "foo bar" }}',
+  result: '"Foo Bar"'
+};

--- a/helpers/strings/capitalizeAll.test.js
+++ b/helpers/strings/capitalizeAll.test.js
@@ -1,0 +1,13 @@
+'use strict';
+const name = getName(__filename),
+  tpl = hbs.compile('{{ capitalizeAll a }}');
+
+describe(name, function () {
+  it('returns emptystring if undefined', function () {
+    expect(tpl()).to.equal('');
+  });
+
+  it('capitalizes every word in a string', function () {
+    expect(tpl({a: 'foo bar'})).to.equal('Foo Bar');
+  });
+});

--- a/helpers/strings/concat.js
+++ b/helpers/strings/concat.js
@@ -1,7 +1,17 @@
 'use strict';
+
+/**
+ * concatenate any number of strings
+ * @return {string} concatenated string
+ */
 module.exports = function () {
   let arg = Array.prototype.slice.call(arguments, 0);
 
   arg.pop();
   return arg.join('');
+};
+
+module.exports.example = {
+  code: '{{ concat "Foo" "Bar" "Baz" }}',
+  result: '"FooBarBaz"'
 };

--- a/helpers/strings/lowercase.js
+++ b/helpers/strings/lowercase.js
@@ -1,0 +1,12 @@
+'use strict';
+const _ = require('lodash');
+
+/**
+ * lower cases a string
+ * _note:_ non-strings will return emptystring
+ * @param  {string} str
+ * @return {string} lower cased
+ */
+module.exports = function (str) {
+  return _.isString(str) ? str.toLowerCase() : '';
+};

--- a/helpers/strings/lowercase.js
+++ b/helpers/strings/lowercase.js
@@ -10,3 +10,8 @@ const _ = require('lodash');
 module.exports = function (str) {
   return _.isString(str) ? str.toLowerCase() : '';
 };
+
+module.exports.example = {
+  code: '{{ lowercase "Foo" }}',
+  result: '"foo"'
+};

--- a/helpers/strings/lowercase.js
+++ b/helpers/strings/lowercase.js
@@ -1,5 +1,4 @@
 'use strict';
-const _ = require('lodash');
 
 /**
  * lower cases a string
@@ -8,7 +7,9 @@ const _ = require('lodash');
  * @return {string} lower cased
  */
 module.exports = function (str) {
-  return _.isString(str) ? str.toLowerCase() : '';
+  if (typeof str === 'string') {
+    return str.toLowerCase();
+  }
 };
 
 module.exports.example = {

--- a/helpers/strings/lowercase.test.js
+++ b/helpers/strings/lowercase.test.js
@@ -1,0 +1,18 @@
+'use strict';
+const name = getName(__filename),
+  tpl = hbs.compile('{{ lowercase a }}');
+
+describe(name, function () {
+  it('returns emptystring if undefined', function () {
+    expect(tpl()).to.equal('');
+    expect(tpl({})).to.equal('');
+  });
+
+  it('returns emptystring if non-string passed in', function () {
+    expect(tpl({a: 123})).to.equal('');
+  });
+
+  it('lower cases a string', function () {
+    expect(tpl({a: 'Per un Pugno di Dollari'})).to.equal('per un pugno di dollari');
+  });
+});

--- a/helpers/strings/replace.js
+++ b/helpers/strings/replace.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * replace all occurrences of `a` with `b`
+ * _note:_ this does simple string replacement, not regex
+ * @param {string} str to replace inside
+ * @param {string} a to replace
+ * @param {string} b the replacement
+ * @returns {string}
+ */
+module.exports = function (str, a, b) {
+  if (str && typeof str === 'string') {
+    if (!a || typeof a !== 'string') return str;
+    if (!b || typeof b !== 'string') b = '';
+    return str.split(a).join(b);
+  }
+};
+
+module.exports.example = {
+  code: '{{ replace "Foo Bar" "Bar" "Baz" }}',
+  result: '"Foo Baz"'
+};

--- a/helpers/strings/replace.test.js
+++ b/helpers/strings/replace.test.js
@@ -1,0 +1,22 @@
+'use strict';
+const name = getName(__filename),
+  tpl = hbs.compile('{{ replace str a b }}');
+
+describe(name, function () {
+  it('returns emptystring if undefined', function () {
+    expect(tpl()).to.equal('');
+    expect(tpl({})).to.equal('');
+  });
+
+  it('should replace occurrences of string "A" with string "B"', function () {
+    expect(tpl({str: 'Bender Bending Rodriguez', a: 'B', b: 'M'})).to.equal('Mender Mending Rodriguez');
+  });
+
+  it('should return the string if `a` is undefined', function () {
+    expect(tpl({str: 'a b c'})).to.equal('a b c');
+  });
+
+  it('should replace the string with "" if `b` is undefined', function () {
+    expect(tpl({str: 'a b c', a: 'a'})).to.equal(' b c');
+  });
+});

--- a/helpers/strings/trim.js
+++ b/helpers/strings/trim.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/**
+ * trim leading and trailing whitespace from a string
+ * @param  {string} str
+ * @return {string}
+ */
+module.exports = function (str) {
+  return typeof str === 'string' ? str.trim() : '';
+};
+
+module.exports.example = {
+  code: '{{ trim "   Foo   " }}',
+  result: '"Foo"'
+};

--- a/helpers/strings/trim.test.js
+++ b/helpers/strings/trim.test.js
@@ -1,0 +1,22 @@
+'use strict';
+const name = getName(__filename),
+  tpl = hbs.compile('{{ trim a }}');
+
+describe(name, function () {
+  it('returns emptystring if undefined', function () {
+    expect(tpl()).to.equal('');
+    expect(tpl({})).to.equal('');
+  });
+
+  it('trims leading whitespace', function () {
+    expect(tpl({a: '   foo'})).to.equal('foo');
+  });
+
+  it('trims trailing whitespace', function () {
+    expect(tpl({a: 'foo    '})).to.equal('foo');
+  });
+
+  it('trims both leading and trailing whitespace', function () {
+    expect(tpl({a: '   foo   '})).to.equal('foo');
+  });
+});

--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 'use strict';
 const glob = require('glob'),
   path = require('path'),
-  // 3rd party helpers, well-maintained
-  hbsHelpers = require('handlebars-helpers'),
-  yaml = require('helper-yaml'),
-  outdent = require('outdent');
+  outdent = require('outdent'),
+  fs = require('fs');
 
 // filter out tests from globbed files
 function noTests(filename) {
@@ -21,9 +19,13 @@ module.exports = function (env) {
   }
 
   // add 3rd party helpers first (in case we need to overwrite any)
-  // docs are here: http://assemble.io/helpers/
-  hbsHelpers({ handlebars: env });
-  env.registerHelper('yaml', yaml.sync);
+  require('./third-party-helpers')(env);
+
+  // support `read` helper on the server-side ONLY
+  // todo: deprecate this when we figure out how to precompile these assets
+  env.registerHelper('read', function (filename) {
+    return fs.readFileSync(filename, 'utf-8');
+  });
 
   // add helpers
   helpers.forEach(h => env.registerHelper(path.basename(h, '.js'), require(h)));

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ const glob = require('glob'),
   path = require('path'),
   // 3rd party helpers, well-maintained
   hbsHelpers = require('handlebars-helpers'),
-  yaml = require('helper-yaml');
+  yaml = require('helper-yaml'),
+  outdent = require('outdent');
 
 // filter out tests from globbed files
 function noTests(filename) {
@@ -31,4 +32,19 @@ module.exports = function (env) {
   partials.forEach(p => env.registerPartial(path.basename(p, '.hbs'), require(p)));
 
   return env;
+};
+
+/**
+ * only render component partials if their _ref or _self exists
+ * @param  {string} name of component
+ * @param  {string} code contents of the template
+ * @return {string}      wrapped template string
+ */
+module.exports.wrapPartial = function (name, code) {
+  return outdent`
+    {{#ifAny _ref _self}}
+      ${code}
+    {{else}}
+      <!-- unable to render partial ${name} without a supplied context -->
+    {{/ifAny}}`;
 };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.6.0",
   "description": "A collection of helpers and partials for handlebars",
   "main": "index.js",
+  "browser": "dist/browser.js",
   "directories": {
     "test": "test"
   },
@@ -10,7 +11,10 @@
     "lint": "eslint helpers partials test index.js",
     "test-local": "npm run lint && istanbul cover _mocha",
     "test": "npm run lint && istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
-    "generate-readme": "node docs/generate-readme.js && git add README.md"
+    "generate-readme": "node docs/generate-readme.js && git add README.md",
+    "build": "webpack",
+    "watch": "webpack -w",
+    "prepublish": "webpack -p"
   },
   "pre-commit": [
     "generate-readme"
@@ -29,14 +33,19 @@
   },
   "homepage": "https://github.com/nymag/nymag-handlebars#readme",
   "devDependencies": {
+    "babel-core": "^6.22.1",
+    "babel-loader": "^6.2.10",
+    "babel-preset-es2015": "^6.22.0",
     "chai": "^3.5.0",
     "chalk": "^1.1.3",
     "coveralls": "^2.11.15",
     "documentation": "^4.0.0-beta.18",
     "eslint": "^3.13.0",
+    "handlebars-template-loader": "^0.7.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
-    "pre-commit": "^1.2.2"
+    "pre-commit": "^1.2.2",
+    "webpack": "^2.2.1"
   },
   "dependencies": {
     "comma-it": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "helper-yaml": "^0.1.0",
     "lodash": "^4.17.4",
     "moment": "^2.17.1",
+    "outdent": "^0.3.0",
     "randomstring": "^1.1.5",
     "speakingurl": "^11.0.0",
     "striptags": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "pre-commit": "^1.2.2",
-    "unlazy-loader": "^0.1.2",
     "webpack": "^2.2.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "glob": "^7.1.1",
     "handlebars": "^4.0.6",
     "he": "^1.1.0",
+    "helper-date": "^0.2.3",
     "helper-yaml": "^0.1.0",
     "lodash": "^4.17.4",
     "moment": "^2.17.1",

--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "pre-commit": "^1.2.2",
+    "unlazy-loader": "^0.1.2",
     "webpack": "^2.2.1"
   },
   "dependencies": {
     "comma-it": "0.0.7",
     "glob": "^7.1.1",
     "handlebars": "^4.0.6",
-    "handlebars-helpers": "^0.7.5",
     "he": "^1.1.0",
     "helper-yaml": "^0.1.0",
     "lodash": "^4.17.4",

--- a/test/index.js
+++ b/test/index.js
@@ -14,11 +14,12 @@ describe('Helpers', function () {
     const name = getName(testFile),
       fn = require(testFile.replace('.test', ''));
 
-    // register the helper
+    // register the helpers first
     hbs.registerHelper(name, fn);
-    // run tests
-    require(testFile);
   });
+
+  // then run tests
+  helperTests.forEach(testFile => require(testFile));
 });
 
 describe('Partials', function () {

--- a/third-party-helpers.js
+++ b/third-party-helpers.js
@@ -1,0 +1,11 @@
+'use strict';
+// a unified collection of third party helpers, used on both the client and the server
+const yaml = require('helper-yaml');
+
+/**
+ * pass an environment in
+ * @param  {handlebars} env
+ */
+module.exports = function (env) {
+  env.registerHelper('yaml', yaml.sync);
+};

--- a/third-party-helpers.js
+++ b/third-party-helpers.js
@@ -1,6 +1,7 @@
 'use strict';
 // a unified collection of third party helpers, used on both the client and the server
-const yaml = require('helper-yaml');
+const yaml = require('helper-yaml'),
+  date = require('helper-date');
 
 /**
  * pass an environment in
@@ -8,4 +9,5 @@ const yaml = require('helper-yaml');
  */
 module.exports = function (env) {
   env.registerHelper('yaml', yaml.sync);
+  env.registerHelper('moment', date);
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,29 @@
+'use strict';
+const path = require('path');
+
+module.exports = {
+  target: 'web',
+  entry: {
+    browser: './client.js'
+  },
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: '[name].js',
+    library: 'nymag-handlebars',
+    libraryTarget: 'commonjs2'
+  },
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      exclude: /node_modules/,
+      loader: 'babel-loader',
+      query: {
+        presets: ['es2015'],
+      }
+    }, {
+      // allows us to require() partials
+      test: /\.hbs$/,
+      loader: 'handlebars-template-loader'
+    }]
+  }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,9 +24,6 @@ module.exports = {
       // allows us to require() partials
       test: /\.hbs$/,
       loader: 'handlebars-template-loader'
-    }, {
-      test: /\.js$/,
-      loader: 'unlazy-loader'
     }]
   },
   resolve: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,10 +25,5 @@ module.exports = {
       test: /\.hbs$/,
       loader: 'handlebars-template-loader'
     }]
-  },
-  resolve: {
-    alias: {
-      handlebars: 'handlebars/dist/handlebars.runtime.min.js' // override handlebars-helpers' require(handlebars)
-    }
   }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,8 +30,5 @@ module.exports = {
     alias: {
       handlebars: 'handlebars/dist/handlebars.runtime.min.js' // override handlebars-helpers' require(handlebars)
     }
-  },
-  node: {
-    fs: 'empty'
   }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,17 @@ module.exports = {
       // allows us to require() partials
       test: /\.hbs$/,
       loader: 'handlebars-template-loader'
+    }, {
+      test: /\.js$/,
+      loader: 'unlazy-loader'
     }]
+  },
+  resolve: {
+    alias: {
+      handlebars: 'handlebars/dist/handlebars.runtime.min.js' // override handlebars-helpers' require(handlebars)
+    }
+  },
+  node: {
+    fs: 'empty'
   }
 };


### PR DESCRIPTION
* removed `handlebars-helpers` (re-wrote all helpers we are currently using)
* added webpack build process for client-side
* broke out `read` helper into server-side version (same as `handlebars-helpers`) and client-side version (noop that returns emptystring) until we figure out a way to nicely inject files at compile-time
* added `wrapPartial` method to server-side code, which will wrap partials in `{{#ifAny _ref _self}}`, allowing them to be used for nymag components.