### PR TITLE
added webpack and lodash optimizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.10",
+    "babel-plugin-lodash": "^3.2.11",
     "babel-preset-es2015": "^6.22.0",
     "chai": "^3.5.0",
     "chalk": "^1.1.3",
@@ -50,6 +51,7 @@
     "eslint": "^3.13.0",
     "handlebars-template-loader": "^0.7.0",
     "istanbul": "^0.4.5",
+    "lodash-webpack-plugin": "^0.11.0",
     "mocha": "^3.2.0",
     "pre-commit": "^1.2.2",
     "webpack": "^2.2.1"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,7 @@
 'use strict';
-const path = require('path');
+const path = require('path'),
+  webpack = require('webpack'),
+  LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 
 module.exports = {
   target: 'web',
@@ -18,6 +20,7 @@ module.exports = {
       exclude: /node_modules/,
       loader: 'babel-loader',
       query: {
+        plugins: ['lodash'],
         presets: ['es2015'],
       }
     }, {
@@ -25,5 +28,11 @@ module.exports = {
       test: /\.hbs$/,
       loader: 'handlebars-template-loader'
     }]
-  }
+  },
+  plugins: [
+    new LodashModuleReplacementPlugin,
+    new webpack.optimize.OccurrenceOrderPlugin,
+    new webpack.optimize.UglifyJsPlugin,
+    new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en/)
+  ]
 };


### PR DESCRIPTION
This should reduce our compiled filesize from 2.2MB to 624kB

* optimize lodash includes (*)
* optimize webpack chunks and uglification
* optimize moment.js locales

(*) Note: _full_ lodash optimizations rely on us using es6 imports, which we can't do right now because of the readme generation. https://github.com/nymag/nymag-handlebars/issues/17