### PR TITLE
addOrderedIds helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ app.set('view engine', 'handlebars');
 
 # Helpers
 
-Currently **44 helpers** in **10 categories**:
+Currently **45 helpers** in **10 categories**:
 
 
 ### arrays
@@ -53,6 +53,7 @@ Currently **44 helpers** in **10 categories**:
 
 ### components
 
+* [**addOrderedIds**](https://github.com/nymag/nymag-handlebars#addorderedids--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/addOrderedIds.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/addOrderedIds.test.js) )
 * [**displaySelf**](https://github.com/nymag/nymag-handlebars#displayself--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelf.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelf.test.js) )
 * [**displaySelfAll**](https://github.com/nymag/nymag-handlebars#displayselfall--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelfAll.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelfAll.test.js) )
 * [**getComponentName**](https://github.com/nymag/nymag-handlebars#getcomponentname--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/getComponentName.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/getComponentName.test.js) )
@@ -179,6 +180,24 @@ return an array of numbers, in order<br /> _note:_  can be used inline or as a b
 
 ## components
 
+
+### addOrderedIds ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/addOrderedIds.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/addOrderedIds.test.js) )
+
+Add ordered ids to components within a componentlist
+
+#### Params
+* `content` _(Array)_ list of components
+* `prefix` _(string)_ prefix for the ids
+* `[offset]` _(number)_ index to start at, defaults to 1
+
+**Returns** _(Array)_ content
+
+#### Example
+
+```hbs
+{{> component-list (addOrderedIds content "annotation-") }}
+
+```
 
 ### displaySelf ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelf.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/components/displaySelf.test.js) )
 

--- a/helpers/components/addOrderedIds.js
+++ b/helpers/components/addOrderedIds.js
@@ -9,12 +9,12 @@ const _ = require('lodash');
  * @return {Array} content
  */
 module.exports = function (content, prefix, offset) {
-  if (offset && typeof offset === 'number') {
-    offset = offset;
+  offset = typeof offset === 'number' ? offset : 1;
+  if (content && prefix) {
+  	return (content || []).map((component, index) => _.set(component, 'orderedId', prefix + (index + offset)));
   } else {
-    offset = 1;
+  	throw new Error('Handlebars Helper "addOrderedIds" needs content and a prefix');
   }
-  return (content || []).map((component, index) => _.set(component, 'orderedId', prefix + (index + offset)));
 };
 
 module.exports.example = {

--- a/helpers/components/addOrderedIds.js
+++ b/helpers/components/addOrderedIds.js
@@ -1,0 +1,22 @@
+'use strict';
+const _ = require('lodash');
+
+/**
+ * Add ordered ids to components within a componentlist
+ * @param {Array} content   list of components
+ * @param {string} prefix   prefix for the ids
+ * @param {number} [offset] index to start at, defaults to 1
+ * @return {Array} content
+ */
+module.exports = function (content, prefix, offset) {
+  if (offset && typeof offset === 'number') {
+    offset = offset;
+  } else {
+    offset = 1;
+  }
+  return (content || []).map((component, index) => _.set(component, 'orderedId', prefix + (index + offset)));
+};
+
+module.exports.example = {
+  code: '{{> component-list (addOrderedIds content "annotation-") }}'
+};

--- a/helpers/components/addOrderedIds.test.js
+++ b/helpers/components/addOrderedIds.test.js
@@ -1,6 +1,8 @@
 'use strict';
 const name = getName(__filename),
-  filter = require('./' + name);
+  tpl = hbs.compile('{{#each (addOrderedIds content "mock-prefix-")}}{{orderedId}}{{/each}}'),
+  tplWithOffset = hbs.compile('{{#each (addOrderedIds content "mock-prefix-" 5)}}{{orderedId}}{{/each}}'),
+  tplWithoutPrefix = hbs.compile('{{#each (addOrderedIds content)}}{{orderedId}}{{/each}}');
 
 describe(name, function () {
   const content = [{
@@ -15,38 +17,26 @@ describe(name, function () {
   }];
 
   it('adds an orderedId property to all components in the list', function () {
-    expect(filter(content, 'mock-prefix-')).to.deep.equal([{
-      _ref: 'localhost/components/fake/instances/1',
-      text: 'hello',
-      orderedId: 'mock-prefix-1'
-    },{
-      _ref: 'localhost/components/fake/instances/2',
-      text: 'hola',
-      orderedId: 'mock-prefix-2'
-    },{
-      _ref: 'localhost/components/fake/instances/3',
-      text: 'bonjour',
-      orderedId: 'mock-prefix-3'
-    }]);
+    expect(tpl({content: content})).to.equal('mock-prefix-1mock-prefix-2mock-prefix-3');
   });
 
   it('adds an orderedId starting at an offset', function () {
-    expect(filter(content, 'mock-prefix-', 10)).to.deep.equal([{
-      _ref: 'localhost/components/fake/instances/1',
-      text: 'hello',
-      orderedId: 'mock-prefix-10'
-    },{
-      _ref: 'localhost/components/fake/instances/2',
-      text: 'hola',
-      orderedId: 'mock-prefix-11'
-    },{
-      _ref: 'localhost/components/fake/instances/3',
-      text: 'bonjour',
-      orderedId: 'mock-prefix-12'
-    }]);
+    expect(tplWithOffset({content: content})).to.equal('mock-prefix-5mock-prefix-6mock-prefix-7');
   });
 
-  it('always returns an array', function () {
-    expect(filter(null)).to.deep.equal([]);
+  it('throws an error if no prefix is passed in', function () {
+    const resultWithoutPrefix = function () {
+      return tplWithoutPrefix();
+    };
+
+    expect(resultWithoutPrefix).to.throw(Error);
+  });
+
+  it('throws an error if no content is passed in', function () {
+    const result = function () {
+      return tpl();
+    };
+
+    expect(result).to.throw(Error);
   });
 });

--- a/helpers/components/addOrderedIds.test.js
+++ b/helpers/components/addOrderedIds.test.js
@@ -1,0 +1,52 @@
+'use strict';
+const name = getName(__filename),
+  filter = require('./' + name);
+
+describe(name, function () {
+  const content = [{
+    _ref: 'localhost/components/fake/instances/1',
+    text: 'hello'
+  },{
+    _ref: 'localhost/components/fake/instances/2',
+    text: 'hola'
+  },{
+    _ref: 'localhost/components/fake/instances/3',
+    text: 'bonjour'
+  }];
+
+  it('adds an orderedId property to all components in the list', function () {
+    expect(filter(content, 'mock-prefix-')).to.deep.equal([{
+      _ref: 'localhost/components/fake/instances/1',
+      text: 'hello',
+      orderedId: 'mock-prefix-1'
+    },{
+      _ref: 'localhost/components/fake/instances/2',
+      text: 'hola',
+      orderedId: 'mock-prefix-2'
+    },{
+      _ref: 'localhost/components/fake/instances/3',
+      text: 'bonjour',
+      orderedId: 'mock-prefix-3'
+    }]);
+  });
+
+  it('adds an orderedId starting at an offset', function () {
+    expect(filter(content, 'mock-prefix-', 10)).to.deep.equal([{
+      _ref: 'localhost/components/fake/instances/1',
+      text: 'hello',
+      orderedId: 'mock-prefix-10'
+    },{
+      _ref: 'localhost/components/fake/instances/2',
+      text: 'hola',
+      orderedId: 'mock-prefix-11'
+    },{
+      _ref: 'localhost/components/fake/instances/3',
+      text: 'bonjour',
+      orderedId: 'mock-prefix-12'
+    }]);
+  });
+
+  it('always returns an array', function () {
+    expect(filter(null)).to.deep.equal([]);
+  });
+});


### PR DESCRIPTION
Adds `addOrderedIds` helper needed for handlebars conversion of `annotations` ([trello](https://trello.com/c/XC69Ob4C/10-annotations))