### PR TITLE
update commaSeparated to maintain pre-existing capitalizations

### DIFF
--- a/helpers/objects/commaSeparated.js
+++ b/helpers/objects/commaSeparated.js
@@ -1,6 +1,11 @@
 'use strict';
 const _ = require('lodash');
 
+// capitalizes the first letter in the first word
+function capitalizeFirstWord(key) {
+  return key.charAt(0).toUpperCase() + key.slice(1);
+}
+
 /**
  * Turn an object into a comma-delineated list of key names, depending if their values are true/false
  * @param  {object} obj
@@ -19,7 +24,7 @@ module.exports = function (obj, shouldCapitalize) {
 
     if (value) {
       result = result ? result + ', ' : result; // if result already has stuff in it, add a comma
-      result += shouldCapitalize ? _.capitalize(key) : key;
+      result += shouldCapitalize ? capitalizeFirstWord(key) : key;
     }
 
     return result;

--- a/helpers/objects/commaSeparated.test.js
+++ b/helpers/objects/commaSeparated.test.js
@@ -18,4 +18,8 @@ describe(name, function () {
   it('capitalizes the first word in items', function () {
     expect(hbs.compile('{{ commaSeparated a true }}')({a: {alpha: true, 'bravo charlie': true}})).to.equal('Alpha, Bravo charlie');
   });
+
+  it('capitalizes the first word in items and maintains other capitalizations', function () {
+    expect(hbs.compile('{{ commaSeparated a true }}')({a: {alpha: true, 'Bravo Charlie-Delta Echo': true}})).to.equal('Alpha, Bravo Charlie-Delta Echo');
+  });
 });


### PR DESCRIPTION
when passing in `true` for `shouldCapitalize` in the `commaSeparated` helper, `_.capitalize` was stripping everything to lowercase and then capitalizing the first word, e.g., `'Cover Story Online'` would turn into `Cover story online`, which would cause feature types in articles to look like: `News-original reporting, Advice, Cover story online`

this fix removes the use of `_.capitalize` and updates it with a function that capitalizes only the first letter in the first word and maintains pre-existing capitalizations 