### PR TITLE
optimizations for bundle size

### DIFF
--- a/README.md
+++ b/README.md
@@ -964,7 +964,7 @@ If a string is over a given length, truncate and append an ellipsis character to
 generate article dates and times, based on a relative format
 
 #### Params
-* `datetime` _(Date|string)_ for  `moment.js`  to parse
+* `datetime` _(Date|string)_ for  `date-fns`  to parse
 
 **Returns** _(string)_ 
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ app.set('view engine', 'handlebars');
 
 # Helpers
 
-Currently **52 helpers** in **10 categories**:
+Currently **53 helpers** in **10 categories**:
 
 
 ### arrays
@@ -122,6 +122,7 @@ Currently **52 helpers** in **10 categories**:
 
 * [**articleDate**](https://github.com/nymag/nymag-handlebars#articledate--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/articleDate.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/articleDate.test.js) )
 * [**formatLocalDate**](https://github.com/nymag/nymag-handlebars#formatlocaldate--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/formatLocalDate.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/formatLocalDate.test.js) )
+* [**moment**](https://github.com/nymag/nymag-handlebars#moment--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/moment.js) | no tests )
 
 ### urls
 
@@ -977,13 +978,19 @@ generate article dates and times, based on a relative format
 
 ### formatLocalDate ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/formatLocalDate.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/formatLocalDate.test.js) )
 
-Formats a date with moment.js
+Formats a date with date-fns
 
 #### Params
 * `date` _(*)_ 
 * `[format]` _(string)_ 
 
 **Returns** _(string)_ 
+
+### moment ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/time/moment.js) | no tests )
+
+_No description_
+
+
 
 ## urls
 

--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ set data into current context or other optional context/object<br /> _note:_  do
 
 #### Params
 * `[obj]` _(object)_ context or object for storing data beyond current context
-* `key` _(string)_ `_.set()`  key/path
+* `key` _(string)_ `_set()`  key/path
 * `val` _(*)_ value to set
 
 #### Example
@@ -747,7 +747,7 @@ Turn an object into a comma-delineated list of key names, depending if their val
 get property in object<br />this is similar to handlebars-helpers'  [`get`](https://github.com/helpers/handlebars-helpers#get) , but the context is called on a returned function.<br />this allows you to easily convert arrays of objects to arrays of a specific property from each objects
 
 #### Params
-* `prop` _(string)_ key/path, passed to  [`_.get()`](https://lodash.com/docs/4.17.4#get)
+* `prop` _(string)_ key/path, passed to  [`_get()`](https://lodash.com/docs/4.17.4#get)
 
 **Returns** value of the property from the object
 
@@ -826,7 +826,7 @@ concatenate any number of strings
 
 ### kebabCase ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/strings/kebabCase.js) | no tests )
 
-straight passthrough to  [`_.kebabCase`](https://lodash.com/docs/4.17.4#kebabCase)
+straight passthrough to  [`_kebabCase`](https://lodash.com/docs/4.17.4#kebabCase)
 
 
 

--- a/client.js
+++ b/client.js
@@ -8,13 +8,9 @@ module.exports = function (env) {
     env = require('handlebars/dist/handlebars.runtime.min.js');
   }
 
-  // add 3rd party helpers first (in case we need to overwrite any)
-  require('./third-party-helpers')(env);
-
-  // add noop to `read` helper on the client-side
-  // todo: deprecate this when we figure out how to precompile these assets
-  // (and thus remove the helper from the server-side)
+  // add noop to `read` and `yaml` helpers on the client-side
   env.registerHelper('read', () => '');
+  env.registerHelper('yaml', () => '');
 
   // add helpers
   helpersReq.keys().forEach(h => env.registerHelper(path.basename(h, '.js'), helpersReq(h)));

--- a/helpers/arrays/join.js
+++ b/helpers/arrays/join.js
@@ -1,5 +1,5 @@
 'use strict';
-const _ = require('lodash');
+const _isArray = require('lodash/isArray');
 
 /**
  * join all elements of array into a string, optionally using a given separator
@@ -8,7 +8,7 @@ const _ = require('lodash');
  * @return {string}
  */
 module.exports = function (array, sep) {
-  if (!_.isArray(array)) {
+  if (!_isArray(array)) {
     return '';
   }
 

--- a/helpers/arrays/map.js
+++ b/helpers/arrays/map.js
@@ -1,5 +1,7 @@
 'use strict';
-const _ = require('lodash');
+const _isArray = require('lodash/isArray'),
+  _map = require('lodash/map'),
+  _isString = require('lodash/isString');
 
 /**
  * map through array, call function on each item
@@ -8,10 +10,10 @@ const _ = require('lodash');
  * @return {array}
  */
 module.exports = function (array, fn) {
-  if (_.isArray(array)) {
-    return _.map(array, fn);
-  } else if (_.isString(array)) {
-    return _.map(array.split(''), fn);
+  if (_isArray(array)) {
+    return _map(array, fn);
+  } else if (_isString(array)) {
+    return _map(array.split(''), fn);
   } else {
     return [];
   }

--- a/helpers/arrays/range.js
+++ b/helpers/arrays/range.js
@@ -1,5 +1,6 @@
 'use strict';
-const _ = require('lodash');
+const _isNumber = require('lodash/isNumber'),
+  _range = require('lodash/range');
 
 /**
  * return an array of numbers, in order
@@ -12,14 +13,14 @@ const _ = require('lodash');
 module.exports = function (start, end, options) {
   let range;
 
-  if (!_.isNumber(end)) {
+  if (!_isNumber(end)) {
     // if they only specify one argument, start from 0
     options = end;
     end = start;
     start = 0;
   }
 
-  range = _.range(start, end);
+  range = _range(start, end);
 
   if (options && options.fn) {
     // block-level, iterate through the range!

--- a/helpers/components/addAnnotatedTextAria.js
+++ b/helpers/components/addAnnotatedTextAria.js
@@ -1,5 +1,6 @@
 'use strict';
-const _ = require('lodash');
+const _includes = require('lodash/includes'),
+  _get = require('lodash/get');
 
 /**
  * Add aria to phrases in paragraphs, corresponds to annotation ids.
@@ -11,8 +12,8 @@ module.exports = function (content) {
 
   return (content || []).map(function (component) {
     if (
-      _.includes(_.get(component, '_ref'), '/clay-paragraph/') &&
-      _.includes(_.get(component, 'text'), 'clay-annotated')
+      _includes(_get(component, '_ref'), '/clay-paragraph/') &&
+      _includes(_get(component, 'text'), 'clay-annotated')
     ) {
       component.text = component.text.replace(
         /\<span class="clay-annotated"/g,

--- a/helpers/components/addInArticleAds.js
+++ b/helpers/components/addInArticleAds.js
@@ -1,7 +1,12 @@
 'use strict';
 /* eslint complexity: ["error", 15] */
 
-const _ = require('lodash'),
+const _property = require('lodash/property'),
+  _has = require('lodash/has'),
+  _isArray = require('lodash/isArray'),
+  _forEach = require('lodash/forEach'),
+  _filter = require('lodash/filter'),
+  _compact = require('lodash/compact'),
   wordcount = require('../html/wordCount.js');
 
 /**
@@ -10,7 +15,7 @@ const _ = require('lodash'),
  * @return {array} of strings
  */
 function getTextContents(component) {
-  return component.content.map(_.property('text'));
+  return component.content.map(_property('text'));
 }
 
 /**
@@ -22,10 +27,10 @@ function getWordCount(component) {
   let contentsWordCount = 0;
 
   // if component has a content componentList, loop through children and count words
-  if (_.has(component, 'content') && _.isArray(component.content)) {
+  if (_has(component, 'content') && _isArray(component.content)) {
 
-    _.forEach(component.content, function (childComponent) {
-      if (_.has(childComponent,'text')) {
+    _forEach(component.content, function (childComponent) {
+      if (_has(childComponent,'text')) {
         contentsWordCount += wordcount(childComponent.text);
       }
     });
@@ -46,13 +51,13 @@ function isTextComponent(component) {
 
   // assumes that if a component has a content property that it is a componentList
   // and might have text components
-  if (_.has(component,'content') && _.isArray(component.content)) {
+  if (_has(component,'content') && _isArray(component.content)) {
     textContents = getTextContents(component);
 
     return !! textContents.length;
   }
 
-  return _.has(component, 'text');
+  return _has(component, 'text');
 
   // note: this assumes that any component with a `text` property
   // is a component that will contain a large block of text,
@@ -70,11 +75,11 @@ function isTextComponent(component) {
 function getComponentType(component) {
   let componentType = '';
 
-  if (_.has(component, 'videoId') || !!component._ref.match(/\/(ooyala-player|video|video-promo)\//ig) ||
-    _.has(component, 'url') && !!component.url.match(/youtube\.com/ig)) {
+  if (_has(component, 'videoId') || !!component._ref.match(/\/(ooyala-player|video|video-promo)\//ig) ||
+    _has(component, 'url') && !!component.url.match(/youtube\.com/ig)) {
     componentType = 'video';
   } else if (!!component._ref.match(/\/(embedly|mediaplay-image|related-stories|related-story|article-sidebar|see-also|tumblr-post)\//ig) ||
-    _.has(component, 'url') && !!component.url.match(/twitter\.com\/|instagram\.com/ig)) {
+    _has(component, 'url') && !!component.url.match(/twitter\.com\/|instagram\.com/ig)) {
     componentType = 'embed';
   } else if (!!component._ref.match(/\/(read-more|walking-tour-slideshow|clay-subheader)\//ig)) {
     componentType = 'ignore';   // explicitly ignore the read more component here, or it will be picked up as text
@@ -115,12 +120,12 @@ function isNearEndOfArticle(content, index) {
   let explodedContent = [],
     remainingTextComponents;
 
-  _.forEach(content,function (component, i) {
+  _forEach(content,function (component, i) {
     if (i > index) {
       // if a component has a content property and it is an array, add that array
       // to be counted. Assumes that it is a component like 'subsection' and that
       // the 'content' array contains other components
-      if (_.has(component,'content') && _.isArray(component.content)) {
+      if (_has(component,'content') && _isArray(component.content)) {
         explodedContent = explodedContent.concat(component.content);
       } else {
         explodedContent.push(component);
@@ -128,7 +133,7 @@ function isNearEndOfArticle(content, index) {
     }
   });
 
-  remainingTextComponents = _.filter(explodedContent, function (val) {
+  remainingTextComponents = _filter(explodedContent, function (val) {
     // get the components that are past the current component (index) and
     // are text components
     return isTextComponent(val);
@@ -229,7 +234,7 @@ module.exports = function (content, articleData, featureTypes) {
     adUnits = articleData.inArticleDesktopOutStreamAd || articleData.inArticleMobileOutStreamAd || articleData.inArticleDesktopPremiumAd || articleData.inArticleTabletAd || articleData.inArticleMobileFirstAd || articleData.inArticleMobileSubsequentAd || articleData.inArticleDesktop300x250;
   }
 
-  _.forEach(content, function (component, index) {
+  _forEach(content, function (component, index) {
     let tempCount = 0,
       componentType,
 
@@ -339,6 +344,5 @@ module.exports = function (content, articleData, featureTypes) {
     }
 
   });
-  return _.compact(newContent); // get rid of undefined ads
+  return _compact(newContent); // get rid of undefined ads
 };
-

--- a/helpers/components/addOrderedIds.js
+++ b/helpers/components/addOrderedIds.js
@@ -1,5 +1,5 @@
 'use strict';
-const _ = require('lodash');
+const _set = require('lodash/set');
 
 /**
  * Add ordered ids to components within a componentlist
@@ -11,7 +11,7 @@ const _ = require('lodash');
 module.exports = function (content, prefix, offset) {
   offset = typeof offset === 'number' ? offset : 1;
   if (content && prefix) {
-  	return content.map((component, index) => _.set(component, 'orderedId', prefix + (index + offset)));
+  	return content.map((component, index) => _set(component, 'orderedId', prefix + (index + offset)));
   } else {
   	throw new Error('Handlebars Helper "addOrderedIds" needs content and a prefix');
   }

--- a/helpers/components/adsToDummies.js
+++ b/helpers/components/adsToDummies.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const _ = require('lodash');
+const _map = require('lodash/map'),
+  _includes = require('lodash/includes');
 
 /**
  * Given a list of component instance objects, replace each ad component
@@ -13,10 +14,10 @@ const _ = require('lodash');
  */
 
 module.exports = function (content) {
-  return _.map(content, function (cmpt) {
+  return _map(content, function (cmpt) {
     var dummy;
 
-    if (_.includes(cmpt._ref, '/components/ad/')) {
+    if (_includes(cmpt._ref, '/components/ad/')) {
       dummy = {
         viewportMin: cmpt.viewportMin,
         viewportMax: cmpt.viewportMax,

--- a/helpers/components/displaySelf.js
+++ b/helpers/components/displaySelf.js
@@ -1,5 +1,5 @@
 'use strict';
-const _ = require('lodash');
+const _filter = require('lodash/filter');
 
 /**
  * Return the first component (from a list of components) with a truthy `displaySelf` property. Used by Spaces.
@@ -9,7 +9,7 @@ const _ = require('lodash');
 module.exports = function (components) {
   var limitReached = false;
 
-  return _.filter(components, function (item) {
+  return _filter(components, function (item) {
     if (item.displaySelf && !limitReached) {
       limitReached = true;
       return item;

--- a/helpers/components/displaySelfAll.js
+++ b/helpers/components/displaySelfAll.js
@@ -1,5 +1,5 @@
 'use strict';
-const _ = require('lodash');
+const _filter = require('lodash/filter');
 
 /**
  * Return all components (from a list of components) with a truthy `displaySelf` property. Used by Spaces.
@@ -7,7 +7,7 @@ const _ = require('lodash');
  * @return {array} all components with `displaySelf: true`
  */
 module.exports = function (components) {
-  return _.filter(components, item => item.displaySelf);
+  return _filter(components, item => item.displaySelf);
 };
 
 module.exports.example = {

--- a/helpers/conditionals/ifAll.js
+++ b/helpers/conditionals/ifAll.js
@@ -1,14 +1,16 @@
 'use strict';
-const _ = require('lodash');
+const _initial = require('lodash/initial'),
+  _last = require('lodash/last'),
+  _takeWhile = require('lodash/takeWhile');
 
 /**
  * block helper for checking if ALL arguments passed in are truthy
  * @return {string} calls block functions
  */
 module.exports = function () {
-  const conditionals = _.initial(arguments),
-    options = _.last(arguments),
-    taken = _.takeWhile(conditionals, c => !!c === true);
+  const conditionals = _initial(arguments),
+    options = _last(arguments),
+    taken = _takeWhile(conditionals, c => !!c === true);
 
     // see if any of the conditionals are falsy without needing to
     // iterate through all of them

--- a/helpers/conditionals/ifAny.js
+++ b/helpers/conditionals/ifAny.js
@@ -1,14 +1,16 @@
 'use strict';
-const _ = require('lodash');
+const _initial = require('lodash/initial'),
+  _last = require('lodash/last'),
+  _find = require('lodash/find');
 
 /**
  * block helper for checking if ANY arguments passed in are truthy
  * @return {string} calls block functions
  */
 module.exports = function () {
-  const conditionals = _.initial(arguments),
-    options = _.last(arguments),
-    truthyFound = _.find(conditionals, function (conditional) {
+  const conditionals = _initial(arguments),
+    options = _last(arguments),
+    truthyFound = _find(conditionals, function (conditional) {
       // see if any of the conditionals are truthy without needing to
       // iterate through all of them (once we've found it)
       return !!conditional === true;

--- a/helpers/conditionals/ifNone.js
+++ b/helpers/conditionals/ifNone.js
@@ -1,14 +1,16 @@
 'use strict';
-const _ = require('lodash');
+const _initial = require('lodash/initial'),
+  _last = require('lodash/last'),
+  _find = require('lodash/find');
 
 /**
  * block helper for checking if NO arguments passed in are truthy
  * @return {string} calls block functions
  */
 module.exports = function () {
-  const conditionals = _.initial(arguments),
-    options = _.last(arguments),
-    truthyFound = _.find(conditionals, function (conditional) {
+  const conditionals = _initial(arguments),
+    options = _last(arguments),
+    truthyFound = _find(conditionals, function (conditional) {
       // see if any of the conditionals are truthy without needing to
       // iterate through all of them (once we've found it)
       return !!conditional === true;
@@ -16,7 +18,7 @@ module.exports = function () {
 
   if (truthyFound !== undefined) {
     // at least one of the conditionals is truthy
-    // so _.find returns quickly without iterating over all of them
+    // so _find returns quickly without iterating over all of them
     return options.inverse(this);
   } else {
     return options.fn(this);

--- a/helpers/conditionals/unlessAll.js
+++ b/helpers/conditionals/unlessAll.js
@@ -1,5 +1,7 @@
 'use strict';
-const _ = require('lodash');
+const _initial = require('lodash/initial'),
+  _last = require('lodash/last'),
+  _takeWhile = require('lodash/takeWhile');
 
 /**
  * block helper for checking that NOT ALL arguments passed in are truthy
@@ -7,9 +9,9 @@ const _ = require('lodash');
  * @return {string} calls block functions
  */
 module.exports = function () {
-  const conditionals = _.initial(arguments),
-    options = _.last(arguments),
-    taken = _.takeWhile(conditionals, c => !!c === true);
+  const conditionals = _initial(arguments),
+    options = _last(arguments),
+    taken = _takeWhile(conditionals, c => !!c === true);
 
     // see if any of the conditionals are falsy without needing to
     // iterate through all of them

--- a/helpers/html/perWordClasses.js
+++ b/helpers/html/perWordClasses.js
@@ -2,7 +2,10 @@
 const striptags = require('striptags'),
   speakingurl = require('speakingurl'),
   he = require('he'),
-  _ = require('lodash');
+  _map = require('lodash/map'),
+  _last = require('lodash/last'),
+  _isEmpty = require('lodash/isEmpty'),
+  _isString = require('lodash/isString');
 
 /**
  * Removes all unicode from string
@@ -56,7 +59,7 @@ function addCharSpan(letter, index) {
 function generateLetterClasses(word) {
   const letters = word.split('');
 
-  return _.map(letters, addCharSpan).join('');
+  return _map(letters, addCharSpan).join('');
 }
 
 /**
@@ -68,7 +71,7 @@ function generateLetterClasses(word) {
  * @returns {string}
  */
 function wrapWord(word, index, array, hasLetterClasses) {
-  const isLastWord = _.last(array) === word,
+  const isLastWord = _last(array) === word,
     suffixSpace = isLastWord ? '' : ' ',
     finalWord = hasLetterClasses ? generateLetterClasses(word) : word;
 
@@ -88,7 +91,7 @@ function wrapWord(word, index, array, hasLetterClasses) {
 module.exports = function (html, options) {
   let words, hasLetterClasses;
 
-  if (_.isEmpty(html) || !_.isString(html)) {
+  if (_isEmpty(html) || !_isString(html)) {
     return ''; // fail gracefully
   }
 
@@ -101,7 +104,7 @@ module.exports = function (html, options) {
 
   // replace nonbreaking spaces before splitting the text
   words = html.split(' ');
-  return _.map(words, (word, index, array) => wrapWord(word, index, array, hasLetterClasses)).join('');
+  return _map(words, (word, index, array) => wrapWord(word, index, array, hasLetterClasses)).join('');
 };
 
 // for testing

--- a/helpers/misc/default.js
+++ b/helpers/misc/default.js
@@ -1,5 +1,7 @@
 'use strict';
-const _ = require('lodash');
+const _isObject = require('lodash/isObject'),
+  _isArray = require('lodash/isArray'),
+  _isEmpty = require('lodash/isEmpty');
 
 /**
  * return the first value if it's not empty, otherwise return the second value
@@ -9,8 +11,8 @@ const _ = require('lodash');
  * @return {*}
  */
 module.exports = function (value, defaultValue) {
-  if (_.isObject(value) || _.isArray(value)) {
-    return !_.isEmpty(value) ? value : defaultValue;
+  if (_isObject(value) || _isArray(value)) {
+    return !_isEmpty(value) ? value : defaultValue;
   } else {
     return !!value ? value : defaultValue;
   }

--- a/helpers/misc/set.js
+++ b/helpers/misc/set.js
@@ -1,22 +1,23 @@
 'use strict';
-const _ = require('lodash');
+const _isString = require('lodash/isString'),
+  _set = require('lodash/set');
 
 /**
  * set data into current context or other optional context/object
  * _note:_ doesn't return anything
  * @param  {object} [obj] context or object for storing data beyond current context
- * @param  {string} key `_.set()` key/path
+ * @param  {string} key `_set()` key/path
  * @param  {*} val value to set
  */
 module.exports = function (obj, key, val) {
 
-  if (_.isString(obj)) {
+  if (_isString(obj)) {
     val = key;
     key = obj;
     obj = this;
   }
 
-  _.set(obj, key, val);
+  _set(obj, key, val);
 };
 
 module.exports.example = {

--- a/helpers/numbers/num.js
+++ b/helpers/numbers/num.js
@@ -1,5 +1,5 @@
 'use strict';
-const _ = require('lodash');
+const _isNaN = require('lodash/isNaN');
 
 /**
  * converts things (usually strings) into numbers
@@ -10,7 +10,7 @@ const _ = require('lodash');
 module.exports = function (x) {
   const num = parseInt(x, 10);
 
-  if (!_.isNaN(num)) {
+  if (!_isNaN(num)) {
     return num;
   } else {
     throw new Error(`Cannot parse ${x} as number!`);

--- a/helpers/objects/commaSeparated.js
+++ b/helpers/objects/commaSeparated.js
@@ -1,5 +1,6 @@
 'use strict';
-const _ = require('lodash');
+const _isObject = require('lodash/isObject'),
+  _reduce = require('lodash/reduce');
 
 // capitalizes the first letter in the first word
 function capitalizeFirstWord(key) {
@@ -13,14 +14,14 @@ function capitalizeFirstWord(key) {
  * @return {string}
  */
 module.exports = function (obj, shouldCapitalize) {
-  if (_.isObject(shouldCapitalize)) {
+  if (_isObject(shouldCapitalize)) {
     // no explicit shouldCapitalize argument passed in
     // (it's seeing the options object passed in as second argument),
     // so default to false
     shouldCapitalize = false;
   }
 
-  return _.reduce(obj, function (result, value, key) {
+  return _reduce(obj, function (result, value, key) {
 
     if (value) {
       result = result ? result + ', ' : result; // if result already has stuff in it, add a comma

--- a/helpers/objects/getProp.js
+++ b/helpers/objects/getProp.js
@@ -1,15 +1,15 @@
 'use strict';
-const _ = require('lodash');
+const _get = require('lodash/get');
 
 /**
  * get property in object
  * this is similar to handlebars-helpers' [`get`](https://github.com/helpers/handlebars-helpers#get), but the context is called on a returned function.
  * this allows you to easily convert arrays of objects to arrays of a specific property from each objects
- * @param  {string} prop key/path, passed to [`_.get()`](https://lodash.com/docs/4.17.4#get)
+ * @param  {string} prop key/path, passed to [`_get()`](https://lodash.com/docs/4.17.4#get)
  * @return {*} value of the property from the object
  */
 module.exports = function (prop) {
-  return (context) => _.get(context, prop);
+  return (context) => _get(context, prop);
 };
 
 module.exports.example = {

--- a/helpers/strings/kebabCase.js
+++ b/helpers/strings/kebabCase.js
@@ -1,10 +1,10 @@
 'use strict';
-const _ = require('lodash');
+const _kebabCase = require('lodash/kebabCase');
 
 /**
- * straight passthrough to [`_.kebabCase`](https://lodash.com/docs/4.17.4#kebabCase)
+ * straight passthrough to [`_kebabCase`](https://lodash.com/docs/4.17.4#kebabCase)
  */
-module.exports = _.kebabCase;
+module.exports = _kebabCase;
 
 module.exports.example = {
   code: '{{ kebabCase "Foo Bar Baz" }}',

--- a/helpers/strings/longestWord.js
+++ b/helpers/strings/longestWord.js
@@ -1,5 +1,6 @@
 'use strict';
-const _ = require('lodash');
+const _isString = require('lodash/isString'),
+  _words = require('lodash/words');
 
 /**
  * returns the number of characters in the longest word of a string. Punctuation is NOT ignored.
@@ -7,11 +8,11 @@ const _ = require('lodash');
  * @return {number} of letters in the longest word
  */
 module.exports = function (str) {
-  if (!_.isString(str)) {
+  if (!_isString(str)) {
     throw new Error('longestWord requires a string argument!');
   }
 
-  return _.words(str).reduce(function (prev, curr) {
+  return _words(str).reduce(function (prev, curr) {
     if (curr.length > prev.length) {
       return curr;
     } else {

--- a/helpers/strings/randomString.js
+++ b/helpers/strings/randomString.js
@@ -1,6 +1,6 @@
 'use strict';
 const randomstring = require('randomstring'),
-  _ = require('lodash');
+  _isString = require('lodash/isString');
 
 /**
  * generate a random string
@@ -15,7 +15,7 @@ module.exports = function (prefix, options) {
     // no prefix defined, options is the first arg
     options = prefix;
     prefix = '';
-  } else if (!_.isString(prefix)) {
+  } else if (!_isString(prefix)) {
     prefix = '';
   }
 

--- a/helpers/strings/truncate.js
+++ b/helpers/strings/truncate.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const _isString = require('lodash/isString');
 
 /**
  * If a string is over a given length, truncate and append an ellipsis character to the end.
@@ -11,7 +11,7 @@ const _ = require('lodash');
  * @return {string}
  */
 module.exports = function (str, len, options) {
-  var suffix = options === undefined || !_.isString(options.hash.suffix) ? '…' : options.hash.suffix;
+  var suffix = options === undefined || !_isString(options.hash.suffix) ? '…' : options.hash.suffix;
 
   if (str && typeof str === 'string') {
     return str.trim().length > len ? str.trim().slice(0, len).trim() + suffix : str.trim();

--- a/helpers/time/articleDate.test.js
+++ b/helpers/time/articleDate.test.js
@@ -1,6 +1,7 @@
 'use strict';
 const name = getName(__filename),
   timeOnly = /^\d+:\d+ [ap]\.m\./,
+  timeAgoSec = /1 second ago/,
   timeAgoSecs = /([12]?\d|30) seconds ago/,
   timeAgoMins = /([12]?\d|30) (min|mins) ago/,
   yesterday = /^Yesterday at \d+:\d+ [ap]\.m\./,
@@ -39,6 +40,15 @@ describe(name, function () {
     var result = tpl({a: new Date()});
 
     expect(result).to.match(timeAgoSecs);
+  });
+
+  it('should show a time ago in seconds if article is created 1 second ago', function () {
+    var date = new Date(),
+      result;
+
+    date = matchSeconds(date, -1);
+    result = tpl({a: date});
+    expect(result).to.match(timeAgoSec);
   });
 
   it('should show a time ago in seconds if article is created < 1 minute ago', function () {

--- a/helpers/time/formatLocalDate.js
+++ b/helpers/time/formatLocalDate.js
@@ -3,7 +3,7 @@ var dateFormat = require('date-fns/format'),
   defaultFormat = 'M/D/YYYY [at] h:mm a';
 
 /**
- * Formats a date with moment.js
+ * Formats a date with date-fns
  *
  * @param  {*} date
  * @param {string} [format]

--- a/helpers/time/formatLocalDate.js
+++ b/helpers/time/formatLocalDate.js
@@ -1,5 +1,5 @@
 'use strict';
-var moment = require('moment'),
+var dateFormat = require('date-fns/format'),
   defaultFormat = 'M/D/YYYY [at] h:mm a';
 
 /**
@@ -12,14 +12,5 @@ var moment = require('moment'),
 module.exports = function (date, format) {
   format = format || defaultFormat;
 
-  // moment defaults to using the local time
-  return moment(date).format(format);
-};
-
-module.exports.setMoment = function (instance) {
-  moment = instance;
-};
-
-module.exports.getDefaultFormat = function () {
-  return defaultFormat;
+  return dateFormat(date, format);
 };

--- a/helpers/time/formatLocalDate.test.js
+++ b/helpers/time/formatLocalDate.test.js
@@ -1,19 +1,20 @@
 'use strict';
 var filterName = __filename.split('/').pop().split('.').shift(),
   filter = require('./' + filterName),
-  expect = require('chai').expect;
+  expect = require('chai').expect,
+  dateFormat = require('date-fns/format');
 
 describe('Filters: ' + filterName, function () {
   it('formats with default format', function () {
-    var expectedResult = '12/31/1969 at 7:00 pm';
+    var date = (new Date(0)).toString();
 
-    expect(filter((new Date(0)).toString())).to.equal(expectedResult);
+    expect(filter(date)).to.equal(dateFormat(date, 'M/D/YYYY [at] h:mm a'));
   });
 
   it('formats with given format', function () {
     var format = 'MM/DD/YYYY',
-      expectedResult = '12/31/1969';
+      date = (new Date(0)).toString();
 
-    expect(filter((new Date(0)).toString(), format)).to.equal(expectedResult);
+    expect(filter(date, format)).to.equal(dateFormat(date, format));
   });
 });

--- a/helpers/time/formatLocalDate.test.js
+++ b/helpers/time/formatLocalDate.test.js
@@ -1,65 +1,19 @@
 'use strict';
-var _ = require('lodash'),
-  filterName = __filename.split('/').pop().split('.').shift(),
+var filterName = __filename.split('/').pop().split('.').shift(),
   filter = require('./' + filterName),
-  expect = require('chai').expect,
-  sinon = require('sinon');
+  expect = require('chai').expect;
 
 describe('Filters: ' + filterName, function () {
-  var sandbox,
-    fakeMomentInstance,
-    fakeMoment;
-
-  function createFakeMoment() {
-    fakeMomentInstance = {
-      format: _.noop
-    };
-
-    fakeMoment = sandbox.stub();
-    fakeMoment.returns(fakeMomentInstance);
-    sandbox.stub(fakeMomentInstance, 'format');
-
-    return fakeMoment;
-  }
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create();
-    filter.setMoment(createFakeMoment());
-  });
-
-  afterEach(function () {
-    sandbox.restore();
-  });
-
   it('formats with default format', function () {
-    var result,
-      date = 'something',
-      defaultFormat = filter.getDefaultFormat(),
-      expectedResult = 'whatever';
+    var expectedResult = '12/31/1969 at 7:00 pm';
 
-    fakeMomentInstance.format.returns(expectedResult);
-
-    result = filter(date);
-
-    sinon.assert.calledWith(fakeMoment, date);
-    sinon.assert.calledWith(fakeMomentInstance.format, defaultFormat);
-
-    expect(result).to.equal(expectedResult);
+    expect(filter((new Date(0)).toString())).to.equal(expectedResult);
   });
 
   it('formats with given format', function () {
-    var result,
-      date = 'something',
-      givenFormat = 'something else',
-      expectedResult = 'whatever';
+    var format = 'MM/DD/YYYY',
+      expectedResult = '12/31/1969';
 
-    fakeMomentInstance.format.returns(expectedResult);
-
-    result = filter(date, givenFormat);
-
-    sinon.assert.calledWith(fakeMoment, date);
-    sinon.assert.calledWith(fakeMomentInstance.format, givenFormat);
-
-    expect(result).to.equal(expectedResult);
+    expect(filter((new Date(0)).toString(), format)).to.equal(expectedResult);
   });
 });

--- a/helpers/time/moment.js
+++ b/helpers/time/moment.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// 'moment' helper is now an alias of 'formatLocalDate'
+module.exports = require('./formatLocalDate');

--- a/helpers/urls/urlencode.js
+++ b/helpers/urls/urlencode.js
@@ -1,5 +1,7 @@
 'use strict';
-const _ = require('lodash');
+const _isString = require('lodash/isString'),
+  _isArray = require('lodash/isArray'),
+  _forOwn = require('lodash/forOwn');
 
 /**
  * encode urls (ported from the nunjucks `urlencode` filter)
@@ -8,19 +10,19 @@ const _ = require('lodash');
  * @return {string} urlencoded data
  */
 module.exports = function (obj) {
-  if (_.isString(obj)) {
+  if (_isString(obj)) {
     return encodeURIComponent(obj);
   } else {
     let parts;
 
-    if (_.isArray(obj)) {
+    if (_isArray(obj)) {
       parts = obj.map(function (item) {
         return encodeURIComponent(item[0]) + '=' + encodeURIComponent(item[1]);
       });
     } else {
       parts = [];
 
-      _.forOwn(obj, function (val, key) {
+      _forOwn(obj, function (val, key) {
         parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(val));
       });
     }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "glob": "^7.1.1",
     "handlebars": "^4.0.6",
     "he": "^1.1.0",
-    "helper-date": "^0.2.3",
     "helper-yaml": "^0.1.0",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -42,16 +42,16 @@
   "devDependencies": {
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.10",
-    "babel-plugin-lodash": "^3.2.11",
     "babel-preset-es2015": "^6.22.0",
     "chai": "^3.5.0",
     "chalk": "^1.1.3",
     "coveralls": "^2.11.15",
+    "date-fns": "^1.28.2",
     "documentation": "^4.0.0-beta.18",
     "eslint": "^3.13.0",
     "handlebars-template-loader": "^0.7.0",
     "istanbul": "^0.4.5",
-    "lodash-webpack-plugin": "^0.11.0",
+    "lodash-webpack-plugin": "^0.11.2",
     "mocha": "^3.2.0",
     "pre-commit": "^1.2.2",
     "webpack": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "comma-it": "0.0.7",
+    "date-fns": "^1.28.2",
     "glob": "^7.1.1",
     "handlebars": "^4.0.6",
     "he": "^1.1.0",
@@ -65,7 +66,6 @@
     "helper-yaml": "^0.1.0",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.4",
-    "moment": "^2.17.1",
     "outdent": "^0.3.0",
     "randomstring": "^1.1.5",
     "sinon": "^2.1.0",

--- a/third-party-helpers.js
+++ b/third-party-helpers.js
@@ -1,5 +1,5 @@
 'use strict';
-// a unified collection of third party helpers, used on both the client and the server
+// a unified collection of third party helpers, used on the server
 const yaml = require('helper-yaml');
 
 /**

--- a/third-party-helpers.js
+++ b/third-party-helpers.js
@@ -1,7 +1,6 @@
 'use strict';
 // a unified collection of third party helpers, used on both the client and the server
-const yaml = require('helper-yaml'),
-  date = require('helper-date');
+const yaml = require('helper-yaml');
 
 /**
  * pass an environment in
@@ -9,5 +8,4 @@ const yaml = require('helper-yaml'),
  */
 module.exports = function (env) {
   env.registerHelper('yaml', yaml.sync);
-  env.registerHelper('moment', date);
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,6 +40,6 @@ module.exports = {
       flattening: true, // allow flattening methods
       paths: true, // allow deep _.get, _.set, _.has
       // note: we're explicitly not allowing chaining, cloning, memoizing, or currying
-    }),
+    })
   ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,6 @@ module.exports = {
       exclude: /node_modules/,
       loader: 'babel-loader',
       query: {
-        plugins: ['lodash'],
         presets: ['es2015'],
       }
     }, {
@@ -30,9 +29,17 @@ module.exports = {
     }]
   },
   plugins: [
-    new LodashModuleReplacementPlugin,
     new webpack.optimize.OccurrenceOrderPlugin,
     new webpack.optimize.UglifyJsPlugin({ output: {inline_script: true} }),
-    new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en/)
+    new LodashModuleReplacementPlugin({
+      shorthands: true, // allow _.map(collection, prop)
+      collections: true, // allow objects in collection methods
+      deburring: true, // remove diacritical marks
+      unicode: true, // support unicode
+      coercions: true, // allow coercions
+      flattening: true, // allow flattening methods
+      paths: true, // allow deep _.get, _.set, _.has
+      // note: we're explicitly not allowing chaining, cloning, memoizing, or currying
+    }),
   ]
 };


### PR DESCRIPTION
* removed `moment` in favor of `date-fns` (fixes #36)
* convert `lodash` includes to require individual methods (fixes #17)
* further webpack lodash optimizations
* removed unused `babel-lodash` plugin
* removed unused client-side `yaml` helper
* removed `moment` helper (and aliased it to `formatLocalDate` (which uses `date-fns`)

BUNDLE SIZES:

* moment (no locale hack) - 812kB
* moment w/ locale hack (what we had before) - **640kB**
* lodash individual requires - 772kB
* lodash w/ module replacement - 764kB
* date-fns - 488kB
* no client-side yaml helper - **444kB**