### PR TITLE
Add ordinal suffix after a number

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,6 @@
 {
   "parserOptions": {
-    // "sourceType": "module", wait until this is an es6 module
     "ecmaVersion": 6,
-    // enable the es6 features supported by our browsers / iojs
     "ecmaFeatures": {
       "arrowFunctions": true,
       "blockBindings": true,
@@ -49,8 +47,7 @@
     "quote-props": [2, "as-needed"],
     "vars-on-top": 2,
     "wrap-iife": 2,
-    // strict mode
-    "strict": [2, "global"],
+    "eqeqeq": 2,
     // variables
     "no-unused-vars": 2,
     // node.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,21 @@
 {
   "parserOptions": {
     // "sourceType": "module", wait until this is an es6 module
-    "ecmaVersion": 6
+    "ecmaVersion": 6,
+    // enable the es6 features supported by our browsers / iojs
+    "ecmaFeatures": {
+      "arrowFunctions": true,
+      "blockBindings": true,
+      "forOf": true,
+      "objectLiteralDuplicateProperties": true,
+      "objectLiteralShorthandProperties": true,
+      "objectLiteralShorthandMethods": true,
+      "octalLiterals": true,
+      "binaryLiterals": true,
+      "templateStrings": true,
+      "generators": true,
+      "modules": true
+    }
   },
   "env": {
     "browser": true,
@@ -14,20 +28,6 @@
     "expect": false,
     "chai": false,
     "sinon": false
-  },
-  // enable the es6 features supported by our browsers / iojs
-  "ecmaFeatures": {
-    "arrowFunctions": true,
-    "blockBindings": true,
-    "forOf": true,
-    "objectLiteralDuplicateProperties": true,
-    "objectLiteralShorthandProperties": true,
-    "objectLiteralShorthandMethods": true,
-    "octalLiterals": true,
-    "binaryLiterals": true,
-    "templateStrings": true,
-    "generators": true,
-    "modules": true
   },
   "rules": {
     // possible errors

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ app.set('view engine', 'handlebars');
 
 # Helpers
 
-Currently **55 helpers** in **10 categories**:
+Currently **56 helpers** in **10 categories**:
 
 
 ### arrays
@@ -90,6 +90,7 @@ Currently **55 helpers** in **10 categories**:
 
 * [**add**](https://github.com/nymag/nymag-handlebars#add--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/add.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/add.test.js) )
 * [**addCommas**](https://github.com/nymag/nymag-handlebars#addcommas--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addCommas.test.js) )
+* [**addOrdinalSuffix**](https://github.com/nymag/nymag-handlebars#addordinalsuffix--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addOrdinalSuffix.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addOrdinalSuffix.test.js) )
 * [**divide**](https://github.com/nymag/nymag-handlebars#divide--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/divide.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/divide.test.js) )
 * [**multiply**](https://github.com/nymag/nymag-handlebars#multiply--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/multiply.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/multiply.test.js) )
 * [**num**](https://github.com/nymag/nymag-handlebars#num--code--tests-) ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/num.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/num.test.js) )
@@ -621,6 +622,22 @@ add commas to numbers.<br /> _note:_  this overrides handlebars-helpers'  `addCo
 ```hbs
 {{ addCommas "1234.50" }}
 //=> "1,234.50"
+```
+
+### addOrdinalSuffix ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addOrdinalSuffix.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/addOrdinalSuffix.test.js) )
+
+add ordinal after a number<br />e.g.  `1`  →  `1st` ,  `2`  →  `2nd` ,  `3`  →  `3rd`
+
+#### Params
+* `i` _(number|string)_ number to add ordinal after
+
+**Returns** _(string)_ 
+
+#### Example
+
+```hbs
+{{ addOrdinalSuffix 1 }}
+//=> 1st
 ```
 
 ### divide ( [code](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/divide.js) | [tests](https://github.com/nymag/nymag-handlebars/blob/master/helpers/numbers/divide.test.js) )

--- a/helpers/conditionals/compare.js
+++ b/helpers/conditionals/compare.js
@@ -6,7 +6,7 @@ const operators = {
   '>': (l, r) => l > r,
   '<=': (l, r) => l <= r,
   '>=': (l, r) => l >= r,
-  typeof: (l, r) => typeof l == r
+  typeof: (l, r) => typeof l === r
 };
 
 /**

--- a/helpers/numbers/addOrdinalSuffix.js
+++ b/helpers/numbers/addOrdinalSuffix.js
@@ -6,11 +6,14 @@
  * @param  {number|string} i number to add ordinal after
  * @return {string}
  */
-
 module.exports = function (i) {
   const j = i % 10,
-        k = i % 100;
-        
+    k = i % 100;
+
+  // if no value is supplied return an empty string
+  if (i == '') {
+    return '';
+  }
   if (j == 1 && k != 11) {
     return i + 'st';
   }

--- a/helpers/numbers/addOrdinalSuffix.js
+++ b/helpers/numbers/addOrdinalSuffix.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * add ordinal after a number
+ * e.g. `1` → `1st`, `2` → `2nd`, `3` → `3rd`
+ * @param  {number|string} i number to add ordinal after
+ * @return {string}
+ */
+
+module.exports = function (i) {
+  const j = i % 10,
+        k = i % 100;
+        
+  if (j == 1 && k != 11) {
+    return i + 'st';
+  }
+  if (j == 2 && k != 12) {
+    return i + 'nd';
+  }
+  if (j == 3 && k != 13) {
+    return i + 'rd';
+  }
+  return i + 'th';
+};
+
+module.exports.example = {
+  code: '{{ addOrdinalSuffix 1 }}',
+  result: '1st'
+};

--- a/helpers/numbers/addOrdinalSuffix.js
+++ b/helpers/numbers/addOrdinalSuffix.js
@@ -11,16 +11,16 @@ module.exports = function (i) {
     k = i % 100;
 
   // if no value is supplied return an empty string
-  if (i == '') {
+  if (i === '') {
     return '';
   }
-  if (j == 1 && k != 11) {
+  if (j === 1 && k !== 11) {
     return i + 'st';
   }
-  if (j == 2 && k != 12) {
+  if (j === 2 && k !== 12) {
     return i + 'nd';
   }
-  if (j == 3 && k != 13) {
+  if (j === 3 && k !== 13) {
     return i + 'rd';
   }
   return i + 'th';

--- a/helpers/numbers/addOrdinalSuffix.js
+++ b/helpers/numbers/addOrdinalSuffix.js
@@ -10,20 +10,18 @@ module.exports = function (i) {
   const j = i % 10,
     k = i % 100;
 
-  // if no value is supplied return an empty string
-  if (i === '') {
-    return '';
-  }
-  if (j === 1 && k !== 11) {
+  // if no number is supplied, pass through string
+  if (i === '' || isNaN(i)) { // will check numbers and (numbers in) strings
+    return new String(i); // will convert to a string if it's a different type
+  } else if (j === 1 && k !== 11) {
     return i + 'st';
-  }
-  if (j === 2 && k !== 12) {
+  } else if (j === 2 && k !== 12) {
     return i + 'nd';
-  }
-  if (j === 3 && k !== 13) {
+  } else if (j === 3 && k !== 13) {
     return i + 'rd';
+  } else {
+    return i + 'th';
   }
-  return i + 'th';
 };
 
 module.exports.example = {

--- a/helpers/numbers/addOrdinalSuffix.test.js
+++ b/helpers/numbers/addOrdinalSuffix.test.js
@@ -1,0 +1,35 @@
+'use strict';
+const name = getName(__filename),
+  tpl = hbs.compile('{{ addCommas a }}');
+
+describe(name, function () {
+  it('fails gracefully', function () {
+    expect(tpl({a: 'foo'})).to.equal('foo');
+  });
+
+  it('should pass through numbers that do not need commas', function () {
+    expect(tpl({a: 123})).to.equal('123');
+  });
+
+  it('should pass through decimals (tens place) that do not need commas', function () {
+    expect(tpl({a: 123.4})).to.equal('123.4');
+  });
+
+  it('should pass through decimals (hundreds place) that do not need commas', function () {
+    expect(tpl({a: '123.40'})).to.equal('123.40'); // preserve zero by passing as a string
+    expect(tpl({a: 123.45})).to.equal('123.45');
+  });
+
+  it('should add commas to intergers', function () {
+    expect(tpl({a: 1234})).to.equal('1,234');
+  });
+
+  it('should add commas to decimals (tens place)', function () {
+    expect(tpl({a: 1234.5})).to.equal('1,234.5');
+  });
+
+  it('should add commas to decimals (hundreds place)', function () {
+    expect(tpl({a: '1234.50'})).to.equal('1,234.50');
+    expect(tpl({a: 1234.56})).to.equal('1,234.56');
+  });
+});

--- a/helpers/numbers/addOrdinalSuffix.test.js
+++ b/helpers/numbers/addOrdinalSuffix.test.js
@@ -1,35 +1,17 @@
 'use strict';
 const name = getName(__filename),
-  tpl = hbs.compile('{{ addCommas a }}');
+  tpl = hbs.compile('{{ addOrdinalSuffix a }}');
 
 describe(name, function () {
   it('fails gracefully', function () {
     expect(tpl({a: 'foo'})).to.equal('foo');
   });
 
-  it('should pass through numbers that do not need commas', function () {
-    expect(tpl({a: 123})).to.equal('123');
+  it('should return a number with an ordinal on the end', function () {
+    expect(tpl({a: 1})).to.equal('1st');
   });
 
-  it('should pass through decimals (tens place) that do not need commas', function () {
-    expect(tpl({a: 123.4})).to.equal('123.4');
-  });
-
-  it('should pass through decimals (hundreds place) that do not need commas', function () {
-    expect(tpl({a: '123.40'})).to.equal('123.40'); // preserve zero by passing as a string
-    expect(tpl({a: 123.45})).to.equal('123.45');
-  });
-
-  it('should add commas to intergers', function () {
-    expect(tpl({a: 1234})).to.equal('1,234');
-  });
-
-  it('should add commas to decimals (tens place)', function () {
-    expect(tpl({a: 1234.5})).to.equal('1,234.5');
-  });
-
-  it('should add commas to decimals (hundreds place)', function () {
-    expect(tpl({a: '1234.50'})).to.equal('1,234.50');
-    expect(tpl({a: 1234.56})).to.equal('1,234.56');
+  it('should return an empty string if no number is provided', function () {
+    expect(tpl({a: ''})).to.equal('');
   });
 });

--- a/helpers/numbers/addOrdinalSuffix.test.js
+++ b/helpers/numbers/addOrdinalSuffix.test.js
@@ -14,4 +14,38 @@ describe(name, function () {
   it('should return an empty string if no number is provided', function () {
     expect(tpl({a: ''})).to.equal('');
   });
+
+  it('should work for string numbers', function () {
+    expect(tpl({ a: '1' })).to.equal('1st');
+  });
+
+  it('should work for numbers ending in 0', function () {
+    expect(tpl({ a: 0 })).to.equal('0th'); // yes, that's correct
+    expect(tpl({ a: 10 })).to.equal('10th');
+    expect(tpl({ a: 20 })).to.equal('20th');
+  });
+
+  it('should work for numbers ending in 1', function () {
+    expect(tpl({ a: 1 })).to.equal('1st');
+    expect(tpl({ a: 11 })).to.equal('11th');
+    expect(tpl({ a: 21 })).to.equal('21st');
+  });
+
+  it('should work for numbers ending in 2', function () {
+    expect(tpl({ a: 2 })).to.equal('2nd');
+    expect(tpl({ a: 12 })).to.equal('12th');
+    expect(tpl({ a: 22 })).to.equal('22nd');
+  });
+
+  it('should work for numbers ending in 3', function () {
+    expect(tpl({ a: 3 })).to.equal('3rd');
+    expect(tpl({ a: 13 })).to.equal('13th');
+    expect(tpl({ a: 23 })).to.equal('23rd');
+  });
+
+  it('should work for numbers ending in 4 and above', function () {
+    expect(tpl({ a: 4 })).to.equal('4th');
+    expect(tpl({ a: 14 })).to.equal('14th');
+    expect(tpl({ a: 24 })).to.equal('24th');
+  });
 });

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "third-party-helpers.js"
   ],
   "scripts": {
-    "lint": "eslint helpers partials test index.js",
+    "lint": "./node_modules/.bin/eslint helpers partials test index.js",
     "test-local": "npm run lint && istanbul cover _mocha",
     "test": "npm run lint && istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "generate-readme": "node docs/generate-readme.js && git add README.md",
@@ -48,7 +48,7 @@
     "coveralls": "^2.11.15",
     "date-fns": "^1.28.2",
     "documentation": "4.0.0-beta15",
-    "eslint": "^3.13.0",
+    "eslint": "^4.4.1",
     "handlebars-template-loader": "^0.7.0",
     "istanbul": "^0.4.5",
     "lodash-webpack-plugin": "^0.11.2",


### PR DESCRIPTION
A helper function that appends an ordinal suffix at the end of a number i.e. '1' -> '1st', '2' -> '2nd' 

Being used for the upcoming competitive house seats interactive.
[Trello](https://trello.com/c/PsC9C3pc/269-xl-daily-intel-competitive-house-seats-2018-midterms)