### PR TITLE
reduce error to warn on filesystem read error

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function (env) {
     try {
       return fs.readFileSync(filename, 'utf-8');
     } catch (error) {
-      log('error', `Failure to read ${filename}.`, { error });
+      log('warn', `Failure to read ${filename}.`, { error });
     }
   });
 


### PR DESCRIPTION
error-level logs eat up our Sentry quota, and these errors are very rarely actionable in prod and high priority; therefore reducing to warn-level